### PR TITLE
Fix quiz question history handling

### DIFF
--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -39,7 +39,14 @@ class QuestionGenerator:
             return None
 
         question = random.choice(unasked)
-        self.state_manager.mark_question_as_asked(area, question)
+        # store only the question ID in history to avoid unhashable entries
+        question_id = question.get("id")
+        if question_id is not None:
+            self.state_manager.mark_question_as_asked(area, question_id)
+        else:
+            logger.warning(
+                f"[QuestionGenerator] Frage ohne ID in '{area}' kann nicht in der Historie gespeichert werden."
+            )
         logger.info(
             f"[QuestionGenerator] Neue Frage für '{area}': {question.get('frage')}")
         return question


### PR DESCRIPTION
## Summary
- ensure question history stores IDs rather than full question objects

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840053a3d08832f8a5b7f3f3efacb4b