### PR TITLE
Fix missing python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 discord.py>=2.5.2
 Unidecode>=1.4.0
 aiosqlite>=0.18.0
+python-dotenv>=1.0.1


### PR DESCRIPTION
## Summary
- add python-dotenv to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68400d8f0a58832faa35181623d5f132