### PR TITLE
Improve setup docs and add env token check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Beispielkonfiguration für den Discord-Bot
+# Kopiere diese Datei zu .env und trage deine Werte ein
+
+discord_token=DEIN_DISCORD_TOKEN
+server_id=DEINE_SERVER_ID

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Diese Dokumentation richtet sich an:
 ## Inhaltsverzeichnis
 
 * [Übersicht & Module](#übersicht--module)
+* [Setup](#setup)
 * [Projektstruktur](#projektstruktur)
 * [Slash-Commands](#slash-commands)
 * [Technische Konzepte](#technische-konzepte)
@@ -36,6 +37,32 @@ Der Bot ist in folgende Module unterteilt:
 | `wcr`      | WCR-spezifische Filter- & Infoabfragen                    |
 
 Jede Funktion ist vollständig über **Slash-Commands** steuerbar.
+
+---
+
+## Setup
+
+1. Alle Abhängigkeiten installieren:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Eine `.env`-Datei im Projektverzeichnis anlegen und dort die folgenden
+   Umgebungsvariablen definieren:
+
+   ```env
+   discord_token=DEIN_DISCORD_TOKEN
+   server_id=DEINE_SERVER_ID
+   ```
+
+3. Den Bot anschließend mit
+
+   ```bash
+   python bot.py
+   ```
+
+   starten.
 
 ---
 

--- a/bot.py
+++ b/bot.py
@@ -118,5 +118,10 @@ class MyBot(commands.Bot):
 
 
 if __name__ == "__main__":
+    token = os.getenv("discord_token")
+    if not token:
+        logger.error("Environment variable 'discord_token' is not set.")
+        exit(1)
+
     bot = MyBot()
-    bot.run(os.getenv("discord_token"))
+    bot.run(token)


### PR DESCRIPTION
## Summary
- add instructions for .env and installation
- provide `.env.example`
- fail fast if `discord_token` is missing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400eb7340c832fa7756e9f69c898c8