### PR TITLE
Fix env token var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Beispielkonfiguration für den Discord-Bot
 # Kopiere diese Datei zu .env und trage deine Werte ein
 
-discord_token=DEIN_DISCORD_TOKEN
+bot_key=DEIN_DISCORD_TOKEN
 server_id=DEINE_SERVER_ID

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Jede Funktion ist vollständig über **Slash-Commands** steuerbar.
    Umgebungsvariablen definieren:
 
    ```env
-   discord_token=DEIN_DISCORD_TOKEN
+   bot_key=DEIN_DISCORD_TOKEN
    server_id=DEINE_SERVER_ID
    ```
 

--- a/bot.py
+++ b/bot.py
@@ -118,9 +118,9 @@ class MyBot(commands.Bot):
 
 
 if __name__ == "__main__":
-    token = os.getenv("discord_token")
+    token = os.getenv("bot_key")
     if not token:
-        logger.error("Environment variable 'discord_token' is not set.")
+        logger.error("Environment variable 'bot_key' is not set.")
         exit(1)
 
     bot = MyBot()


### PR DESCRIPTION
## Summary
- revert environment variable name to `bot_key`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684012026c10832f9b7f95cfa5997684