### PR TITLE
Fix missing data_loader import

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ LotusGamingDE/
 │  └─ wcr/
 │     ├─ __init__.py
 │     ├─ cog.py
-│     ├─ data_loader.py
 │     ├─ slash_commands.py
 │     └─ helpers.py
 ├─ data/

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -4,7 +4,6 @@ import discord
 from discord.ext import commands
 import os
 import logging
-from . import data_loader
 from . import helpers
 from .views import MiniSelectView
 import itertools


### PR DESCRIPTION
## Summary
- remove outdated `data_loader` import in WCRCog
- update README to match current file layout

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840138a2234832f833b90945bbd1e92