### PR TITLE
Implement champion score and rank commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,12 @@ LotusGamingDE/
 /champion remove       # Punkte abziehen
 /champion set          # Punkte direkt setzen
 /champion reset        # Punkte zurücksetzen
-/champion info         # Eigene Punkte anzeigen
+/champion score        # Punkte von dir oder anderen anzeigen
+/champion myhistory    # Eigenen Verlauf einsehen
 /champion history      # Verlauf einzelner User
 /champion leaderboard  # Rangliste anzeigen
+/champion roles        # Schwellen der Champion-Rollen
+/champion rank         # Rang eines Users
 ```
 
 ### Quiz Modul

--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -126,6 +126,27 @@ class ChampionData:
 
         return [(r[0], r[1]) for r in rows]
 
+    async def get_rank(self, user_id: str) -> Optional[tuple[int, int]]:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                "SELECT total FROM points WHERE user_id = ?",
+                (user_id,),
+            )
+            row = await cur.fetchone()
+            if not row:
+                return None
+            total = row[0]
+
+            cur = await db.execute(
+                "SELECT COUNT(*) FROM points WHERE total > ?",
+                (total,),
+            )
+            count_row = await cur.fetchone()
+            rank = count_row[0] + 1
+
+        return rank, total
+
 
 class ChampionCog(commands.Cog):
     def __init__(self, bot: commands.Bot):


### PR DESCRIPTION
## Summary
- add `/champion score`, `/champion myhistory`, `/champion roles`, `/champion rank`
- drop old `/champion info` command
- document new commands in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840140ea0cc832f8eb671aa0f26bbce