### PR TITLE
Fix missing quiz_data attribute

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -43,6 +43,9 @@ class MyBot(commands.Bot):
         self.main_guild_id = int(guild_id)
         self.main_guild = discord.Object(id=self.main_guild_id)
         self.data = {}
+        # Provide a default attribute so cogs relying on ``quiz_data`` don't fail
+        # if no configuration was loaded yet.
+        self.quiz_data = {}
 
     async def setup_hook(self):
         # Optional: Commands leeren für Guild (verhindert Ghost-Kommandos bei Updates)

--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -23,8 +23,13 @@ class QuizCog(commands.Cog):
         self.answered_users: dict[str, set[int]] = defaultdict(set)
         self.awaiting_activity: dict[int, tuple[str, float]] = {}
 
+        # ``quiz_data`` might be empty if no areas are configured. In that case
+        # fall back to a fresh ``QuestionStateManager`` so the cog can start
+        # without raising an exception during initialization.
         self.state: QuestionStateManager = next(
-            cfg["question_state"] for cfg in self.bot.quiz_data.values()
+            (cfg.get("question_state") for cfg in self.bot.quiz_data.values()
+             if "question_state" in cfg),
+            QuestionStateManager("data/pers/quiz/question_state.json")
         )
 
         self.tracker = MessageTracker(bot=self.bot)


### PR DESCRIPTION
## Summary
- make `quiz_data` a default attribute on the bot
- fallback to default `QuestionStateManager` when no quiz areas exist

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684017a9e008832fa46378c16ae68491