### PR TITLE
Add dynamic question limit and activity threshold commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ LotusGamingDE/
 /quiz enable           # Quiz aktivieren (mit Area und Sprache)
 /quiz language         # Sprache für diesen Channel wechseln
 /quiz time             # Zeitfenster (z. B. alle 15 Minuten)
+/quiz dynamic          # Anzahl dynamischer Fragen anpassen
+/quiz threshold        # Nachrichten-Schwelle vor automatischen Fragen
 /quiz reset            # Fragehistorie zurücksetzen
 ```
 

--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -16,14 +16,14 @@ class QuestionGenerator:
         self.dynamic_providers = dynamic_providers
         logger.info("[QuestionGenerator] QuestionGenerator initialized.")
 
-    def generate(self, area: str = None) -> Dict[str, Any] | None:
+    def generate(self, area: str = None, max_dynamic: int = 5) -> Dict[str, Any] | None:
         if not area:
             logger.warning("[QuestionGenerator] Keine Area angegeben.")
             return None
 
         if area in self.dynamic_providers:
             provider = self.dynamic_providers[area]
-            questions = [provider.generate() for _ in range(5)]
+            questions = [provider.generate() for _ in range(max_dynamic)]
             questions = [q for q in questions if q]
             logger.debug(
                 f"[QuestionGenerator] Dynamisch generierte Fragen für '{area}': {len(questions)}")

--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -38,11 +38,14 @@ class QuestionManager:
             self.cog.tracker.set_initialized(cid)
             logger.info(
                 f"[QuestionManager] Channel '{channel.name}' ({area}) initialisiert – überspringe Aktivitätsprüfung.")
-        elif self.cog.tracker.get(cid) < 10:
-            logger.info(
-                f"[QuestionManager] Nachrichtenzähler für '{area}': {self.cog.tracker.get(cid)}/10 – warte auf Aktivität.")
-            self.cog.awaiting_activity[cid] = (area, end_time)
-            return
+        else:
+            threshold = cfg.get("activity_threshold", 10)
+            if self.cog.tracker.get(cid) < threshold:
+                logger.info(
+                    f"[QuestionManager] Nachrichtenzähler für '{area}': {self.cog.tracker.get(cid)}/{threshold} – warte auf Aktivität."
+                )
+                self.cog.awaiting_activity[cid] = (area, end_time)
+                return
 
         logger.info(
             f"[QuestionManager] Bedingungen erfüllt – sende Frage für '{area}'.")
@@ -53,7 +56,8 @@ class QuestionManager:
         channel = self.bot.get_channel(cfg["channel_id"])
         qg = cfg["question_generator"]
 
-        question = qg.generate(area)
+        max_dyn = cfg.get("max_dynamic_questions", 5)
+        question = qg.generate(area, max_dynamic=max_dyn)
         if not question:
             logger.warning(
                 f"[QuestionManager] Keine Frage generiert für '{area}'.")


### PR DESCRIPTION
## Summary
- allow configuring number of dynamic questions and activity threshold via `/quiz dynamic` and `/quiz threshold`
- honour new settings in `MessageTracker` and `QuestionManager`
- support passing dynamic question count to `QuestionGenerator`
- document new slash commands in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684013faaa80832fa76bfd1c879648ca