### PR TITLE
Refactor WCR dynamic question logic

### DIFF
--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -16,17 +16,17 @@ class QuestionGenerator:
         self.dynamic_providers = dynamic_providers
         logger.info("[QuestionGenerator] QuestionGenerator initialized.")
 
-    def generate(self, area: str = None, max_dynamic: int = 5) -> Dict[str, Any] | None:
+    def generate(self, area: str = None) -> Dict[str, Any] | None:
         if not area:
             logger.warning("[QuestionGenerator] Keine Area angegeben.")
             return None
 
         if area in self.dynamic_providers:
             provider = self.dynamic_providers[area]
-            questions = [provider.generate() for _ in range(max_dynamic)]
-            questions = [q for q in questions if q]
+            question = provider.generate()
+            questions = [question] if question else []
             logger.debug(
-                f"[QuestionGenerator] Dynamisch generierte Fragen für '{area}': {len(questions)}")
+                f"[QuestionGenerator] Dynamische Frage für '{area}': {len(questions)}")
         else:
             questions = self.questions_by_area.get("de", {}).get(area, [])
             logger.debug(

--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -56,8 +56,7 @@ class QuestionManager:
         channel = self.bot.get_channel(cfg["channel_id"])
         qg = cfg["question_generator"]
 
-        max_dyn = cfg.get("max_dynamic_questions", 5)
-        question = qg.generate(area, max_dynamic=max_dyn)
+        question = qg.generate(area)
         if not question:
             logger.warning(
                 f"[QuestionManager] Keine Frage generiert für '{area}'.")

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -46,7 +46,6 @@ def save_area_config(bot: commands.Bot):
             "window_timer": int(cfg["time_window"].total_seconds() / 60),
             "language": cfg["language"],
             "active": cfg.get("active", False),
-            "max_dynamic_questions": cfg.get("max_dynamic_questions", 5),
             "activity_threshold": cfg.get("activity_threshold", 10)
         }
     with open(AREA_CONFIG_PATH, "w", encoding="utf-8") as f:
@@ -82,21 +81,6 @@ async def language(interaction: discord.Interaction, lang: Literal["de", "en"]):
     save_area_config(interaction.client)
 
     await interaction.response.send_message(f"🌐 Sprache für **{area}** auf **{lang}** gesetzt.", ephemeral=True)
-
-
-@quiz_group.command(name="dynamic", description="Maximale Anzahl dynamischer Fragen einstellen")
-@app_commands.describe(count="Anzahl generierter Fragen (1–20)")
-@app_commands.default_permissions(manage_guild=True)
-async def dynamic(interaction: discord.Interaction, count: app_commands.Range[int, 1, 20]):
-    area = get_area_by_channel(interaction.client, interaction.channel.id)
-    if not area:
-        await interaction.response.send_message("❌ In diesem Channel ist kein Quiz konfiguriert.", ephemeral=True)
-        return
-
-    interaction.client.quiz_data[area]["max_dynamic_questions"] = count
-    save_area_config(interaction.client)
-
-    await interaction.response.send_message(f"🔢 Dynamische Fragen: **{count}**", ephemeral=True)
 
 
 @quiz_group.command(name="threshold", description="Aktivitätsschwelle für automatische Fragen setzen")

--- a/tests/test_wcr_question_provider.py
+++ b/tests/test_wcr_question_provider.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import json
+import random
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cogs.quiz.area_providers.wcr import WCRQuestionProvider
+
+class DummyBot:
+    pass
+
+def create_provider():
+    bot = DummyBot()
+    bot.data = {
+        "wcr": {
+            "units": json.load(open("data/wcr/units.json", "r", encoding="utf-8")),
+            "locals": {
+                "de": json.load(open("data/wcr/locals/de.json", "r", encoding="utf-8")),
+                "en": json.load(open("data/wcr/locals/en.json", "r", encoding="utf-8")),
+            },
+            "pictures": json.load(open("data/wcr/pictures.json", "r", encoding="utf-8")),
+        }
+    }
+    return WCRQuestionProvider(bot, language="de")
+
+
+def test_generate_type_1():
+    provider = create_provider()
+    q = provider.generate_type_1()
+    assert q is not None
+    assert "frage" in q and "antwort" in q and "id" in q
+
+
+def test_generate_type_2():
+    provider = create_provider()
+    q = provider.generate_type_2()
+    assert q is not None
+    assert "frage" in q and "antwort" in q and "id" in q
+
+
+def test_generate_type_3():
+    provider = create_provider()
+    q = provider.generate_type_3()
+    assert q is not None
+    assert "frage" in q and "antwort" in q and "id" in q
+
+
+def test_generate_type_4(monkeypatch):
+    provider = create_provider()
+    # make selection deterministic
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    q = provider.generate_type_4()
+    assert q is not None
+    assert "frage" in q and "antwort" in q and "id" in q
+
+
+def test_generate_type_5(monkeypatch):
+    provider = create_provider()
+    units = provider.units
+    monkeypatch.setattr(random, "sample", lambda seq, k: [units[0], units[1]])
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    q = provider.generate_type_5()
+    assert q is not None
+    assert "frage" in q and "antwort" in q and "id" in q


### PR DESCRIPTION
## Summary
- give WCR questions stable IDs and pick among valid types without retries
- simplify `QuestionGenerator` to only request a single dynamic question
- drop obsolete dynamic question count command
- update tests for new ID field

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401877aaf8832f9acfdd0d8a9aac28