### PR TITLE
Add quiz generator and tracker tests

### DIFF
--- a/tests/test_message_tracker.py
+++ b/tests/test_message_tracker.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cogs.quiz.message_tracker import MessageTracker
+
+
+class DummyAuthor:
+    def __init__(self, is_bot=False):
+        self.bot = is_bot
+
+
+class DummyChannel:
+    def __init__(self, cid):
+        self.id = cid
+
+
+class DummyMessage:
+    def __init__(self, cid, is_bot=False):
+        self.author = DummyAuthor(is_bot)
+        self.channel = DummyChannel(cid)
+
+
+class DummyManager:
+    def __init__(self):
+        self.scheduled = []
+
+    async def ask_question(self, area, end_time):
+        self.scheduled.append((area, end_time))
+
+
+class DummyCog:
+    def __init__(self):
+        self.manager = DummyManager()
+        self.awaiting_activity = {}
+
+
+class DummyBot:
+    def __init__(self):
+        self.quiz_cog = DummyCog()
+        self.quiz_data = {"area1": {"channel_id": 123, "activity_threshold": 3}}
+
+
+def test_register_message_increments_and_triggers(monkeypatch):
+    bot = DummyBot()
+    tracker = MessageTracker(bot)
+    bot.quiz_cog.awaiting_activity = {123: ("area1", "end")}
+
+    triggered = []
+
+    def fake_task(coro, logger):
+        triggered.append(coro)
+        coro.close()
+
+    monkeypatch.setattr("cogs.quiz.message_tracker.create_logged_task", fake_task)
+
+    msg = DummyMessage(123)
+    tracker.register_message(msg)
+    assert tracker.get(123) == 1
+    tracker.register_message(msg)
+    assert tracker.get(123) == 2
+    assert len(triggered) == 0
+    tracker.register_message(msg)
+    assert tracker.get(123) == 3
+    assert len(triggered) == 1

--- a/tests/test_question_generator.py
+++ b/tests/test_question_generator.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cogs.quiz.question_generator import QuestionGenerator
+
+
+class DummyStateManager:
+    def __init__(self):
+        self.asked = {}
+
+    def filter_unasked_questions(self, area, questions):
+        asked = set(self.asked.get(area, []))
+        return [q for q in questions if q.get("id") not in asked]
+
+    def mark_question_as_asked(self, area, question_id):
+        self.asked.setdefault(area, []).append(question_id)
+
+
+def create_generator():
+    questions = {"de": {"area1": [
+        {"id": 1, "frage": "f1", "antwort": "a1"},
+        {"id": 2, "frage": "f2", "antwort": "a2"},
+    ]}}
+    return QuestionGenerator(questions, DummyStateManager(), {})
+
+
+def test_generate_selects_unasked(monkeypatch):
+    gen = create_generator()
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+
+    q1 = gen.generate("area1")
+    assert q1["id"] == 1
+
+    q2 = gen.generate("area1")
+    assert q2["id"] == 2
+
+    assert gen.generate("area1") is None
+
+
+def test_generate_handles_missing_area(monkeypatch):
+    state = DummyStateManager()
+    gen = QuestionGenerator({"de": {}}, state, {})
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+
+    assert gen.generate("missing") is None
+    assert gen.generate(None) is None


### PR DESCRIPTION
## Summary
- add regression tests for `MessageTracker` activity logic
- test `QuestionGenerator.generate` question selection logic and error cases

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684025348aa0832f850c6bde4b588eff