### PR TITLE
Add tests for utils and question state

### DIFF
--- a/tests/test_question_state_manager.py
+++ b/tests/test_question_state_manager.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import json
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cogs.quiz.question_state import QuestionStateManager
+
+
+def test_set_active_question(tmp_path):
+    state_file = tmp_path / "state.json"
+    manager = QuestionStateManager(str(state_file))
+    question = {"id": 1, "text": "foo"}
+    manager.set_active_question("area1", question)
+
+    assert manager.get_active_question("area1") == question
+
+    with open(state_file, "r", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved["active"]["area1"] == question
+
+
+def test_mark_question_as_asked(tmp_path):
+    state_file = tmp_path / "state.json"
+    manager = QuestionStateManager(str(state_file))
+    manager.mark_question_as_asked("area1", 42)
+    manager.mark_question_as_asked("area1", 42)
+
+    assert manager.get_asked_questions("area1") == [42]
+
+    with open(state_file, "r", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved["history"]["area1"] == [42]
+
+
+def test_filter_unasked_questions(tmp_path):
+    state_file = tmp_path / "state.json"
+    manager = QuestionStateManager(str(state_file))
+    manager.mark_question_as_asked("area1", 1)
+    manager.mark_question_as_asked("area1", 3)
+
+    questions = [
+        {"id": 1},
+        {"id": 2},
+        {"id": 3},
+        {"id": 4},
+    ]
+
+    filtered = manager.filter_unasked_questions("area1", questions)
+    filtered_ids = [q["id"] for q in filtered]
+
+    assert filtered_ids == [2, 4]

--- a/tests/test_utils_functions.py
+++ b/tests/test_utils_functions.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cogs.quiz.utils import create_permutations, create_permutations_list, normalize_text
+
+
+def test_create_permutations():
+    perms = set(create_permutations("Café-au Lait!"))
+    expected = {"café-au lait!", "cafe-au lait!", "caféau lait", "cafeau lait"}
+    assert perms == expected
+
+
+def test_create_permutations_list():
+    result = set(create_permutations_list(["Café", "Tea"]))
+    expected = set(create_permutations("Café")) | set(create_permutations("Tea"))
+    assert result == expected
+
+
+def test_normalize_text():
+    assert normalize_text("  Héllo,   Wörld!! ") == "hello world"


### PR DESCRIPTION
## Summary
- test permutations and normalization helpers
- cover question state manager methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840250c0514832fa25e7abeec26048a