### PR TITLE
Handle missing server_id

### DIFF
--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -20,14 +20,16 @@ from .duel import DuelInviteView, DuelConfig
 logger = get_logger(__name__)
 
 SERVER_ID = os.getenv("server_id")
-if not SERVER_ID:
-    raise ValueError("Environment variable 'server_id' is not set.")
-GUILD_ID = int(SERVER_ID)
-
+if SERVER_ID:
+    GUILD_ID = int(SERVER_ID)
+    guild_ids = [GUILD_ID]
+else:
+    logger.warning("Environment variable 'server_id' is not set.")
+    guild_ids = None
 quiz_group = app_commands.Group(
     name="quiz",
     description="Quiz‐Befehle",
-    guild_ids=[GUILD_ID]
+    guild_ids=guild_ids,
 )
 
 AREA_CONFIG_PATH = "data/pers/quiz/areas.json"

--- a/cogs/wcr/__init__.py
+++ b/cogs/wcr/__init__.py
@@ -1,6 +1,5 @@
 # cogs/wcr/__init__.py
 
-import os
 import discord
 
 from log_setup import get_logger
@@ -10,10 +9,6 @@ from .slash_commands import wcr_group
 
 logger = get_logger(__name__)  # z.B. "cogs.wcr.__init__"
 
-SERVER_ID = os.getenv("server_id")
-if SERVER_ID is None:
-    raise ValueError("Environment variable 'server_id' is not set.")
-MAIN_SERVER_ID = int(SERVER_ID)
 
 
 async def setup(bot: discord.ext.commands.Bot):
@@ -21,7 +16,7 @@ async def setup(bot: discord.ext.commands.Bot):
         await bot.add_cog(WCRCog(bot))
         bot.tree.add_command(
             wcr_group,
-            guild=discord.Object(id=MAIN_SERVER_ID)
+            guild=bot.main_guild
         )
         logger.info(
             "[WCRCog] Cog und Slash-Command-Gruppe erfolgreich registriert.")

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -11,13 +11,6 @@ from .views import MiniSelectView
 
 logger = get_logger(__name__)
 
-# Hauptserver-ID aus der Umgebungsvariablen lesen
-SERVER_ID = os.getenv('server_id')
-if SERVER_ID is None:
-    raise ValueError("Environment variable 'server_id' is not set.")
-MAIN_SERVER_ID = int(SERVER_ID)
-
-
 class WCRCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot

--- a/cogs/wcr/slash_commands.py
+++ b/cogs/wcr/slash_commands.py
@@ -2,16 +2,21 @@ import discord
 from discord import app_commands
 from .cog import WCRCog
 import os
+from log_setup import get_logger
 
+logger = get_logger(__name__)
 SERVER_ID = os.getenv('server_id')
-if SERVER_ID is None:
-    raise ValueError("Environment variable 'server_id' is not set.")
-MAIN_SERVER_ID = int(SERVER_ID)
+if SERVER_ID:
+    MAIN_SERVER_ID = int(SERVER_ID)
+    guild_ids = [MAIN_SERVER_ID]
+else:
+    logger.warning("Environment variable 'server_id' is not set.")
+    guild_ids = None
 
 wcr_group = app_commands.Group(
     name="wcr",
     description="Befehle für Warcraft Rumble",
-    guild_ids=[MAIN_SERVER_ID]  # Nur auf deinem Server
+    guild_ids=guild_ids  # Nur auf deinem Server
 )
 
 # Autocomplete-Wrapper


### PR DESCRIPTION
## Summary
- don't raise import errors when `server_id` isn't provided
- log a warning and register slash commands globally when unset
- remove unused env checks in WCR cog
- register WCR commands using `bot.main_guild`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840303978cc832f8996b266e56b8dac