### PR TITLE
Remove server id env usage from WCR cog

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -11,12 +11,6 @@ from .views import MiniSelectView
 
 logger = get_logger(__name__)
 
-# Hauptserver-ID aus der Umgebungsvariablen lesen
-SERVER_ID = os.getenv('server_id')
-if SERVER_ID is None:
-    raise ValueError("Environment variable 'server_id' is not set.")
-MAIN_SERVER_ID = int(SERVER_ID)
-
 
 class WCRCog(commands.Cog):
     def __init__(self, bot):


### PR DESCRIPTION
## Summary
- clean up `cogs/wcr/cog.py` by removing obsolete environment variable logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402fc6f224832fa74ea53f62e822b1