### PR TITLE
Install pytest-asyncio plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py>=2.5.2
 Unidecode>=1.4.0
 aiosqlite>=0.18.0
 python-dotenv>=1.0.1
+pytest-asyncio>=0.23.5


### PR DESCRIPTION
## Summary
- allow asyncio tests by adding `pytest-asyncio` to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684033fd0090832f9d89338b4163c17c