### PR TITLE
Fix quiz manager state path & tracker setup

### DIFF
--- a/cogs/quiz/__init__.py
+++ b/cogs/quiz/__init__.py
@@ -9,6 +9,7 @@ from .question_closer import QuestionCloser
 from .message_tracker import MessageTracker
 from .slash_commands import quiz_group
 from .utils import get_available_areas
+from bot import QUESTION_STATE_PATH
 
 logger = get_logger(__name__)
 
@@ -17,8 +18,8 @@ async def setup(bot: commands.Bot):
     logger.info("[QuizInit] Initialisierung startet...")
 
     areas = get_available_areas()
-    state_manager = QuestionStateManager(areas)
-    tracker = MessageTracker()
+    state_manager = QuestionStateManager(QUESTION_STATE_PATH)
+    tracker = MessageTracker(bot)
     dynamic_providers = {}
 
     for area in areas:


### PR DESCRIPTION
## Summary
- load question state via the configured `QUESTION_STATE_PATH`
- pass the bot to `MessageTracker`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684035867f68832f8a4b372286e6d47b