### PR TITLE
Add global env fixture for server ID

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import pytest
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("server_id", "0")


### PR DESCRIPTION
## Summary
- ensure tests run with `server_id` configured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684039a63058832f995ce0194fa6c16f