### PR TITLE
Make server_id optional for quiz group

### DIFF
--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -20,14 +20,15 @@ from .duel import DuelInviteView, DuelConfig
 logger = get_logger(__name__)
 
 SERVER_ID = os.getenv("server_id")
-if not SERVER_ID:
-    raise ValueError("Environment variable 'server_id' is not set.")
-GUILD_ID = int(SERVER_ID)
+GUILD_ID = int(SERVER_ID) if SERVER_ID else None
 
+group_kwargs = {}
+if GUILD_ID is not None:
+    group_kwargs["guild_ids"] = [GUILD_ID]
 quiz_group = app_commands.Group(
     name="quiz",
     description="Quiz‐Befehle",
-    guild_ids=[GUILD_ID]
+    **group_kwargs
 )
 
 AREA_CONFIG_PATH = "data/pers/quiz/areas.json"


### PR DESCRIPTION
## Summary
- make `server_id` optional in `quiz_group`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684039a58fdc832f99e11f85eef96089