### PR TITLE
Remove unused guild id env

### DIFF
--- a/cogs/quiz/__init__.py
+++ b/cogs/quiz/__init__.py
@@ -1,4 +1,5 @@
 import discord
+from discord.ext import commands
 
 from log_setup import get_logger
 

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -1,6 +1,5 @@
 # cogs/quiz/slash_commands.py
 
-import os
 import json
 import datetime
 
@@ -19,16 +18,9 @@ from .duel import DuelInviteView, DuelConfig
 
 logger = get_logger(__name__)
 
-SERVER_ID = os.getenv("server_id")
-GUILD_ID = int(SERVER_ID) if SERVER_ID else None
-
-group_kwargs = {}
-if GUILD_ID is not None:
-    group_kwargs["guild_ids"] = [GUILD_ID]
 quiz_group = app_commands.Group(
     name="quiz",
     description="Quiz‐Befehle",
-    **group_kwargs
 )
 
 AREA_CONFIG_PATH = "data/pers/quiz/areas.json"


### PR DESCRIPTION
## Summary
- simplify quiz slash command loading by dropping guild ids
- import commands in quiz initialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403bec211c832fa876200d495a7b35