### PR TITLE
Add test for quiz setup and fix circular import

### DIFF
--- a/cogs/quiz/__init__.py
+++ b/cogs/quiz/__init__.py
@@ -11,13 +11,14 @@ from .question_state import QuestionStateManager
 from .question_closer import QuestionCloser
 from .message_tracker import MessageTracker
 from .utils import get_available_areas
-from bot import QUESTION_STATE_PATH
 
 logger = get_logger(__name__)
 
 
 async def setup(bot: commands.Bot):
     logger.info("[QuizInit] Initialisierung startet...")
+
+    from bot import QUESTION_STATE_PATH
 
     from .slash_commands import quiz_group
 
@@ -36,16 +37,15 @@ async def setup(bot: commands.Bot):
                 f"[QuizInit] Kein dynamischer Provider für '{area}': {e}")
 
     generator = QuestionGenerator(
-        questions_by_area=bot.quiz_data["questions"],
+        questions_by_area=bot.quiz_data.get("questions", {}),
         state_manager=state_manager,
         dynamic_providers=dynamic_providers,
     )
 
-    manager = QuestionManager(bot, generator, state_manager, tracker)
-    closer = QuestionCloser(bot, state_manager)
+    bot.quiz_generator = generator  # expose for potential use
 
-    bot.add_cog(manager)
-    bot.add_cog(closer)
+    quiz_cog = QuizCog(bot)
+    await bot.add_cog(quiz_cog)
     bot.tree.add_command(quiz_group, guild=bot.main_guild)
 
     logger.info(

--- a/tests/test_quiz_setup.py
+++ b/tests/test_quiz_setup.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from bot import MyBot
+from cogs import quiz
+from cogs.quiz.slash_commands import quiz_group
+import cogs.quiz.cog as quiz_cog_mod
+import cogs.quiz.message_tracker as msg_mod
+
+
+@pytest.mark.asyncio
+async def test_quiz_setup_registers_cog_and_commands(monkeypatch):
+    def fake_task(coro, logger):
+        coro.close()
+
+    monkeypatch.setattr(quiz_cog_mod, "create_logged_task", fake_task)
+    monkeypatch.setattr(msg_mod, "create_logged_task", fake_task)
+
+    bot = MyBot()
+    bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
+    bot.quiz_data = {"questions": {}}
+
+    await quiz.setup(bot)
+
+    assert bot.get_cog("QuizCog") is not None
+    registered = [cmd.name for cmd in bot.tree.get_commands(guild=bot.main_guild)]
+    assert quiz_group.name in registered


### PR DESCRIPTION
## Summary
- remove circular import by lazily importing QUESTION_STATE_PATH
- register QuizCog in quiz.setup
- add test ensuring quiz cog registration and command setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404171dc58832fb0a92972118b85c9