### PR TITLE
Fix helpers imports

### DIFF
--- a/cogs/wcr/helpers.py
+++ b/cogs/wcr/helpers.py
@@ -1,6 +1,5 @@
 # cogs/wcr/helpers.py
-import os
-import itertools
+
 
 from log_setup import get_logger
 


### PR DESCRIPTION
## Summary
- remove unused imports from `wcr` helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840416da23c832fb6fccbe93ec15602