### PR TITLE
Fix language selection in quiz questions

### DIFF
--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -17,7 +17,7 @@ class QuestionGenerator:
         self.dynamic_providers = dynamic_providers
         logger.info("[QuestionGenerator] QuestionGenerator initialized.")
 
-    def generate(self, area: str = None) -> Dict[str, Any] | None:
+    def generate(self, area: str = None, language: str = "de") -> Dict[str, Any] | None:
         if not area:
             logger.warning("[QuestionGenerator] Keine Area angegeben.")
             return None
@@ -29,7 +29,7 @@ class QuestionGenerator:
             logger.debug(
                 f"[QuestionGenerator] Dynamische Frage für '{area}': {len(questions)}")
         else:
-            questions = self.questions_by_area.get("de", {}).get(area, [])
+            questions = self.questions_by_area.get(language, {}).get(area, [])
             logger.debug(
                 f"[QuestionGenerator] Statische Fragen für '{area}': {len(questions)}")
 

--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -57,7 +57,8 @@ class QuestionManager:
         channel = self.bot.get_channel(cfg["channel_id"])
         qg = cfg["question_generator"]
 
-        question = qg.generate(area)
+        language = cfg.get("language", "de")
+        question = qg.generate(area, language=language)
         if not question:
             logger.warning(
                 f"[QuestionManager] Keine Frage generiert für '{area}'.")


### PR DESCRIPTION
## Summary
- allow specifying the language when generating quiz questions
- ensure QuestionManager passes the area's language to the generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404168e3bc832f8223a412cfd8f9a8