### PR TITLE
Fix quiz setup to avoid duplicate cog

### DIFF
--- a/cogs/quiz/__init__.py
+++ b/cogs/quiz/__init__.py
@@ -45,7 +45,7 @@ async def setup(bot: commands.Bot):
     bot.quiz_generator = generator  # expose for potential use
 
     quiz_cog = QuizCog(bot)
-    await bot.add_cog(quiz_cog)
+    await bot.add_cog(quiz_cog, override=True)
     bot.tree.add_command(quiz_group, guild=bot.main_guild)
 
     logger.info(


### PR DESCRIPTION
## Summary
- ensure the quiz setup doesn't fail when the cog is already registered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684049f26244832fb78d31efa9de894f