### PR TITLE
Use utils to load WCR data

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from log_setup import setup_logging, get_logger
 from cogs.quiz.question_state import QuestionStateManager
 from cogs.quiz.question_generator import QuestionGenerator
+from cogs.wcr.utils import load_wcr_data
 
 # Lade Umgebungsvariablen
 load_dotenv()
@@ -118,14 +119,7 @@ class MyBot(commands.Bot):
             quiz_languages.append(lang)
 
         # WCR-Daten zentral laden
-        wcr_data = {
-            "units": load_json("data/wcr/units.json"),
-            "pictures": load_json("data/wcr/pictures.json"),
-            "locals": {
-                "de": load_json("data/wcr/locals/de.json"),
-                "en": load_json("data/wcr/locals/en.json"),
-            },
-        }
+        wcr_data = load_wcr_data()
 
         # Champion-Rollen laden
         champion_roles = load_json("data/champion/roles.json")

--- a/cogs/wcr/utils.py
+++ b/cogs/wcr/utils.py
@@ -56,6 +56,6 @@ def load_wcr_data():
     """Fasst alle WCR-Daten zusammen, wie sie im Bot verwendet werden."""
     return {
         "units": load_units(),
-        "languages": load_languages(),
-        "pictures": load_pictures()
+        "locals": load_languages(),
+        "pictures": load_pictures(),
     }


### PR DESCRIPTION
## Summary
- add `load_wcr_data` import in `bot.py`
- load WCR data using the helper instead of manual JSON files
- adjust `load_wcr_data` to return `locals` key

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405789d58c832fb020f5d7a4278858