### PR TITLE
Persist ChampionData sqlite connection

### DIFF
--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -17,77 +17,85 @@ class ChampionData:
 
     def __init__(self, db_path: str):
         self.db_path = db_path
+        self.db: aiosqlite.Connection | None = None
         self._init_done = False
 
     async def init_db(self):
-        """
-        Legt Tabellen an, falls sie noch nicht existieren.
-        Wird nur einmal pro Lauf ausgeführt.
-        """
+        """Stellt die Datenbankverbindung her und legt Tabellen an."""
+        if self.db is None:
+            os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+            self.db = await aiosqlite.connect(self.db_path)
+
         if self._init_done:
             return
         self._init_done = True
 
-        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
-
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute("""
-                CREATE TABLE IF NOT EXISTS points (
-                    user_id TEXT PRIMARY KEY,
-                    total INTEGER NOT NULL
-                );
-            """)
-            await db.execute("""
-                CREATE TABLE IF NOT EXISTS history (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    user_id TEXT NOT NULL,
-                    delta INTEGER NOT NULL,
-                    reason TEXT NOT NULL,
-                    date TEXT NOT NULL
-                );
-            """)
-            await db.commit()
+        await self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS points (
+                user_id TEXT PRIMARY KEY,
+                total INTEGER NOT NULL
+            );
+            """
+        )
+        await self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                delta INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                date TEXT NOT NULL
+            );
+            """
+        )
+        await self.db.commit()
 
         logger.info("[ChampionData] SQLite‐Datenbank initialisiert.")
 
+    async def close(self):
+        """Schließt die gehaltene Datenbankverbindung."""
+        if self.db is not None:
+            await self.db.close()
+            self.db = None
+            self._init_done = False
+
     async def get_total(self, user_id: str) -> int:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?", (user_id,)
-            )
-            row = await cur.fetchone()
-            return row[0] if row else 0
+        cur = await self.db.execute(
+            "SELECT total FROM points WHERE user_id = ?", (user_id,)
+        )
+        row = await cur.fetchone()
+        return row[0] if row else 0
 
     async def add_delta(self, user_id: str, delta: int, reason: str) -> int:
         await self.init_db()
         now = datetime.utcnow().isoformat()
 
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?", (user_id,)
+        cur = await self.db.execute(
+            "SELECT total FROM points WHERE user_id = ?", (user_id,)
+        )
+        row = await cur.fetchone()
+        current_total = row[0] if row else 0
+
+        new_total = current_total + delta
+        if row:
+            await self.db.execute(
+                "UPDATE points SET total = ? WHERE user_id = ?",
+                (new_total, user_id)
             )
-            row = await cur.fetchone()
-            current_total = row[0] if row else 0
-
-            new_total = current_total + delta
-            if row:
-                await db.execute(
-                    "UPDATE points SET total = ? WHERE user_id = ?",
-                    (new_total, user_id)
-                )
-            else:
-                await db.execute(
-                    "INSERT INTO points(user_id, total) VALUES (?, ?)",
-                    (user_id, new_total)
-                )
-
-            await db.execute(
-                "INSERT INTO history(user_id, delta, reason, date) VALUES (?, ?, ?, ?)",
-                (user_id, delta, reason, now)
+        else:
+            await self.db.execute(
+                "INSERT INTO points(user_id, total) VALUES (?, ?)",
+                (user_id, new_total)
             )
 
-            await db.commit()
+        await self.db.execute(
+            "INSERT INTO history(user_id, delta, reason, date) VALUES (?, ?, ?, ?)",
+            (user_id, delta, reason, now)
+        )
+
+        await self.db.commit()
 
         logger.info(
             f"[ChampionData] {user_id} Punkte geändert um {delta} ({reason}). Neuer Total: {new_total}."
@@ -96,55 +104,52 @@ class ChampionData:
 
     async def get_history(self, user_id: str, limit: int = 10) -> list[dict]:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                """
-                SELECT delta, reason, date
-                  FROM history
-                 WHERE user_id = ?
-                 ORDER BY date DESC
-                 LIMIT ?
-                """,
-                (user_id, limit)
-            )
-            rows = await cur.fetchall()
+        cur = await self.db.execute(
+            """
+            SELECT delta, reason, date
+              FROM history
+             WHERE user_id = ?
+             ORDER BY date DESC
+             LIMIT ?
+            """,
+            (user_id, limit)
+        )
+        rows = await cur.fetchall()
 
         return [{"delta": r[0], "reason": r[1], "date": r[2]} for r in rows]
 
     async def get_leaderboard(self, limit: int = 10, offset: int = 0) -> list[tuple[str, int]]:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                """
-                SELECT user_id, total
-                  FROM points
-                 ORDER BY total DESC
-                 LIMIT ? OFFSET ?
-                """,
-                (limit, offset)
-            )
-            rows = await cur.fetchall()
+        cur = await self.db.execute(
+            """
+            SELECT user_id, total
+              FROM points
+             ORDER BY total DESC
+             LIMIT ? OFFSET ?
+            """,
+            (limit, offset)
+        )
+        rows = await cur.fetchall()
 
         return [(r[0], r[1]) for r in rows]
 
     async def get_rank(self, user_id: str) -> Optional[tuple[int, int]]:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?",
-                (user_id,),
-            )
-            row = await cur.fetchone()
-            if not row:
-                return None
-            total = row[0]
+        cur = await self.db.execute(
+            "SELECT total FROM points WHERE user_id = ?",
+            (user_id,),
+        )
+        row = await cur.fetchone()
+        if not row:
+            return None
+        total = row[0]
 
-            cur = await db.execute(
-                "SELECT COUNT(*) FROM points WHERE total > ?",
-                (total,),
-            )
-            count_row = await cur.fetchone()
-            rank = count_row[0] + 1
+        cur = await self.db.execute(
+            "SELECT COUNT(*) FROM points WHERE total > ?",
+            (total,),
+        )
+        count_row = await cur.fetchone()
+        rank = count_row[0] + 1
 
         return rank, total
 

--- a/tests/test_champion_data.py
+++ b/tests/test_champion_data.py
@@ -21,6 +21,7 @@ async def test_add_and_get_total(tmp_path):
     assert final_total == 7
 
     assert db_path.exists()
+    await data.close()
     db_path.unlink()
     assert not db_path.exists()
 
@@ -37,6 +38,7 @@ async def test_get_history(tmp_path):
     assert [entry["delta"] for entry in history] == [3, 2, 1]
     assert [entry["reason"] for entry in history] == ["third", "second", "first"]
 
+    await data.close()
     db_path.unlink()
     assert not db_path.exists()
 
@@ -55,5 +57,6 @@ async def test_leaderboard_and_rank(tmp_path):
     rank = await data.get_rank("C")
     assert rank == (2, 7)
 
+    await data.close()
     db_path.unlink()
     assert not db_path.exists()


### PR DESCRIPTION
## Summary
- keep a persistent connection in `ChampionData`
- use the connection for all DB queries and commit operations
- add `close` method for shutdown cleanup
- adapt champion database tests to close the connection

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840575f4ce4832f88659124fa4e7925