### PR TITLE
Align question provider interface

### DIFF
--- a/cogs/quiz/area_providers/base.py
+++ b/cogs/quiz/area_providers/base.py
@@ -1,7 +1,7 @@
 # cogs/quiz/area_providers/base.py
 
 from abc import ABC, abstractmethod
-from typing import List, Dict
+from typing import Dict, Optional
 
 from log_setup import get_logger
 
@@ -10,6 +10,6 @@ logger = get_logger(__name__)
 
 class DynamicQuestionProvider(ABC):
     @abstractmethod
-    def generate_questions(self, count: int) -> List[Dict]:
-        """Generiert dynamisch eine bestimmte Anzahl an Fragen"""
+    def generate(self) -> Optional[Dict]:
+        """Generiert eine einzelne Frage."""
         pass

--- a/cogs/quiz/area_providers/wcr.py
+++ b/cogs/quiz/area_providers/wcr.py
@@ -4,11 +4,12 @@ from log_setup import get_logger
 import logging
 import hashlib
 from ..utils import create_permutations_list
+from .base import DynamicQuestionProvider
 
 logger = get_logger(__name__)
 
 
-class WCRQuestionProvider:
+class WCRQuestionProvider(DynamicQuestionProvider):
     def __init__(self, bot, language="de"):
         units_data = bot.data["wcr"].get("units", [])
         # ``units.json`` may wrap the list of units in a top level key

--- a/tests/test_wcr_question_provider.py
+++ b/tests/test_wcr_question_provider.py
@@ -7,6 +7,7 @@ import random
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from cogs.quiz.area_providers.wcr import WCRQuestionProvider
+from cogs.quiz.area_providers.base import DynamicQuestionProvider
 
 class DummyBot:
     pass
@@ -24,6 +25,11 @@ def create_provider():
         }
     }
     return WCRQuestionProvider(bot, language="de")
+
+
+def test_provider_inherits_base():
+    provider = create_provider()
+    assert isinstance(provider, DynamicQuestionProvider)
 
 
 def test_generate_type_1():


### PR DESCRIPTION
## Summary
- rename abstract method to `generate` in `DynamicQuestionProvider`
- make `WCRQuestionProvider` inherit from the base class
- add a unit test ensuring that the WCR provider uses the base class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840575a86fc832f89120e3633a3d85d