### PR TITLE
Improve logging context for quiz operations

### DIFF
--- a/cogs/quiz/question_closer.py
+++ b/cogs/quiz/question_closer.py
@@ -3,8 +3,6 @@ import asyncio
 
 from log_setup import get_logger
 
-logger = get_logger(__name__)
-
 
 class QuestionCloser:
     def __init__(self, bot, state):
@@ -12,6 +10,7 @@ class QuestionCloser:
         self.state = state
 
     async def close_question(self, area: str, qinfo: dict, timed_out=False, winner: discord.User = None, correct_answer: str = None):
+        logger = get_logger(__name__, area=area)
         cfg = self.bot.quiz_data[area]
         channel = self.bot.get_channel(cfg["channel_id"])
 

--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -7,7 +7,6 @@ from log_setup import get_logger
 
 from .views import AnswerButtonView
 
-logger = get_logger(__name__)
 
 
 class QuestionManager:
@@ -16,6 +15,7 @@ class QuestionManager:
         self.bot = cog.bot
 
     async def prepare_question(self, area: str, end_time: datetime.datetime):
+        logger = get_logger(__name__, area=area)
         cfg = self.bot.quiz_data[area]
 
         if not cfg.get("active"):
@@ -53,6 +53,7 @@ class QuestionManager:
         await self.ask_question(area, end_time)
 
     async def ask_question(self, area: str, end_time: datetime.datetime):
+        logger = get_logger(__name__, area=area)
         cfg = self.bot.quiz_data[area]
         channel = self.bot.get_channel(cfg["channel_id"])
         qg = cfg["question_generator"]

--- a/cogs/quiz/scheduler.py
+++ b/cogs/quiz/scheduler.py
@@ -4,8 +4,6 @@ import datetime
 
 from log_setup import get_logger, create_logged_task
 
-logger = get_logger(__name__)
-
 
 class QuizScheduler:
     def __init__(self, bot, area: str, prepare_question_callback, close_question_callback):
@@ -13,12 +11,13 @@ class QuizScheduler:
         self.area = area
         self.prepare_question = prepare_question_callback
         self.close_question = close_question_callback
-        self.task = create_logged_task(self.run(), logger)
+        self.logger = get_logger(__name__, area=area)
+        self.task = create_logged_task(self.run(), self.logger)
 
     async def run(self):
         await self.bot.wait_until_ready()
         if self.area not in self.bot.quiz_data:
-            logger.warning(
+            self.logger.warning(
                 f"[Scheduler] '{self.area}' nicht in quiz_data vorhanden.")
             return
 
@@ -37,7 +36,7 @@ class QuizScheduler:
             post_time = next_time + \
                 datetime.timedelta(seconds=random.uniform(0, 10))
 
-            logger.info(
+            self.logger.info(
                 f"[Scheduler] Neues Zeitfenster für '{self.area}' bis {window_end:%H:%M}. "
                 f"Frage geplant für ca. {post_time:%H:%M:%S}"
             )
@@ -46,11 +45,11 @@ class QuizScheduler:
             await asyncio.sleep((post_time - next_time).total_seconds())
 
             if self.area not in self.bot.quiz_data:
-                logger.warning(
+                self.logger.warning(
                     f"[Scheduler] '{self.area}' nicht mehr in quiz_data.")
                 return
 
-            logger.debug(
+            self.logger.debug(
                 f"[Scheduler] Wache auf – prüfe Bedingungen für '{self.area}'...")
             await self.prepare_question(self.area, window_end)
 


### PR DESCRIPTION
## Summary
- create area-specific loggers in `QuizScheduler`
- instantiate loggers with area context when managing or closing questions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684056e0f2a8832f8e0c237285431a8e