### PR TITLE
Use dataclass for quiz configuration

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from log_setup import setup_logging, get_logger
 from cogs.quiz.question_state import QuestionStateManager
 from cogs.quiz.question_generator import QuestionGenerator
+from cogs.quiz.quiz_config import QuizAreaConfig
 
 # Lade Umgebungsvariablen
 load_dotenv()
@@ -70,15 +71,15 @@ def load_quiz_config(bot: commands.Bot):
             dynamic_providers=dynamic_providers,
         )
 
-        bot.quiz_data[area] = {
-            "channel_id": cfg.get("channel_id"),
-            "time_window": time_window,
-            "language": language,
-            "active": cfg.get("active", False),
-            "activity_threshold": cfg.get("activity_threshold", 10),
-            "question_state": state,
-            "question_generator": generator,
-        }
+        bot.quiz_data[area] = QuizAreaConfig(
+            channel_id=cfg.get("channel_id"),
+            time_window=time_window,
+            language=language,
+            active=cfg.get("active", False),
+            activity_threshold=cfg.get("activity_threshold", 10),
+            question_state=state,
+            question_generator=generator,
+        )
 
     logger.info(f"[bot] Quiz-Konfiguration geladen: {list(bot.quiz_data.keys())}")
 

--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -31,8 +31,7 @@ class QuizCog(commands.Cog):
         # fall back to a fresh ``QuestionStateManager`` so the cog can start
         # without raising an exception during initialization.
         self.state: QuestionStateManager = next(
-            (cfg.get("question_state") for cfg in self.bot.quiz_data.values()
-             if "question_state" in cfg),
+            (cfg.question_state for cfg in self.bot.quiz_data.values() if cfg.question_state),
             QuestionStateManager("data/pers/quiz/question_state.json")
         )
 
@@ -47,7 +46,7 @@ class QuizCog(commands.Cog):
         self.restorer.restore_all()
 
         for area, cfg in self.bot.quiz_data.items():
-            if cfg.get("active"):
+            if cfg.active:
                 QuizScheduler(
                     bot=self.bot,
                     area=area,

--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -138,7 +138,7 @@ class QuizDuelGame:
         self.scores = {challenger.id: 0, opponent.id: 0}
 
     async def run(self):
-        qg: QuestionGenerator = self.cog.bot.quiz_data[self.area]["question_generator"]
+        qg: QuestionGenerator = self.cog.bot.quiz_data[self.area].question_generator
         total_rounds = {"bo3": 3, "bo5": 5}.get(self.mode, 5)
         needed = total_rounds // 2 + 1
         logger.info(

--- a/cogs/quiz/message_tracker.py
+++ b/cogs/quiz/message_tracker.py
@@ -19,7 +19,7 @@ class MessageTracker:
         await self.bot.wait_until_ready()
 
         for area, cfg in self.bot.quiz_data.items():
-            channel_id = cfg["channel_id"]
+            channel_id = cfg.channel_id
             try:
                 start = time.time()
                 channel = await self.bot.fetch_channel(channel_id)
@@ -33,7 +33,7 @@ class MessageTracker:
                                    if msg.author.id == self.bot.user.id and msg.embeds and
                                    msg.embeds[0].title.startswith(f"Quiz für {area.upper()}")), None)
 
-                threshold = cfg.get("activity_threshold", 10)
+                threshold = cfg.activity_threshold
                 if quiz_index is not None:
                     count = len([
                         m for m in messages[:quiz_index] if not m.author.bot
@@ -65,7 +65,8 @@ class MessageTracker:
             )
 
         if cid in self.bot.quiz_cog.awaiting_activity:
-            threshold = self.bot.quiz_data.get(area, {}).get("activity_threshold", 10) if area else 10
+            cfg_obj = self.bot.quiz_data.get(area) if area else None
+            threshold = cfg_obj.activity_threshold if cfg_obj else 10
             if after >= threshold:
                 if area is None:
                     area, _ = self.bot.quiz_cog.awaiting_activity[cid]
@@ -83,7 +84,7 @@ class MessageTracker:
 
     def _find_area_for_channel(self, channel_id: int) -> str | None:
         for area, cfg in self.bot.quiz_data.items():
-            if cfg["channel_id"] == channel_id:
+            if cfg.channel_id == channel_id:
                 return area
         return None
 

--- a/cogs/quiz/question_closer.py
+++ b/cogs/quiz/question_closer.py
@@ -13,7 +13,7 @@ class QuestionCloser:
 
     async def close_question(self, area: str, qinfo: dict, timed_out=False, winner: discord.User = None, correct_answer: str = None):
         cfg = self.bot.quiz_data[area]
-        channel = self.bot.get_channel(cfg["channel_id"])
+        channel = self.bot.get_channel(cfg.channel_id)
 
         try:
             msg = await channel.fetch_message(qinfo["message_id"])
@@ -39,7 +39,7 @@ class QuestionCloser:
 
         self.bot.quiz_cog.current_questions.pop(area, None)
         self.state.clear_active_question(area)
-        self.bot.quiz_cog.tracker.set_initialized(cfg["channel_id"])
+        self.bot.quiz_cog.tracker.set_initialized(cfg.channel_id)
 
     async def auto_close(self, area: str, delay: float):
         await asyncio.sleep(delay)

--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -18,12 +18,12 @@ class QuestionManager:
     async def prepare_question(self, area: str, end_time: datetime.datetime):
         cfg = self.bot.quiz_data[area]
 
-        if not cfg.get("active"):
+        if not cfg.active:
             logger.info(
                 f"[QuestionManager] Area '{area}' ist inaktiv – keine Frage stellen.")
             return
 
-        channel = self.bot.get_channel(cfg["channel_id"])
+        channel = self.bot.get_channel(cfg.channel_id)
         if not channel:
             logger.warning(
                 f"[QuestionManager] Channel für '{area}' nicht gefunden.")
@@ -40,7 +40,7 @@ class QuestionManager:
             logger.info(
                 f"[QuestionManager] Channel '{channel.name}' ({area}) initialisiert – überspringe Aktivitätsprüfung.")
         else:
-            threshold = cfg.get("activity_threshold", 10)
+            threshold = cfg.activity_threshold
             if self.cog.tracker.get(cid) < threshold:
                 logger.info(
                     f"[QuestionManager] Nachrichtenzähler für '{area}': {self.cog.tracker.get(cid)}/{threshold} – warte auf Aktivität."
@@ -54,10 +54,10 @@ class QuestionManager:
 
     async def ask_question(self, area: str, end_time: datetime.datetime):
         cfg = self.bot.quiz_data[area]
-        channel = self.bot.get_channel(cfg["channel_id"])
-        qg = cfg["question_generator"]
+        channel = self.bot.get_channel(cfg.channel_id)
+        qg = cfg.question_generator
 
-        language = cfg.get("language", "de")
+        language = cfg.language
         question = qg.generate(area, language=language)
         if not question:
             logger.warning(

--- a/cogs/quiz/question_restorer.py
+++ b/cogs/quiz/question_restorer.py
@@ -35,7 +35,7 @@ class QuestionRestorer:
 
     async def repost_question(self, area: str, qinfo: dict):
         cfg = self.bot.quiz_data[area]
-        channel = await self.bot.fetch_channel(cfg["channel_id"])
+        channel = await self.bot.fetch_channel(cfg.channel_id)
 
         if not channel:
             logger.error(f"[Restorer] Channel für '{area}' nicht verfügbar.")

--- a/cogs/quiz/quiz_config.py
+++ b/cogs/quiz/quiz_config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from typing import Optional
+
+from .question_state import QuestionStateManager
+from .question_generator import QuestionGenerator
+
+
+@dataclass
+class QuizAreaConfig:
+    channel_id: Optional[int] = None
+    time_window: datetime.timedelta = datetime.timedelta(minutes=15)
+    language: str = "de"
+    active: bool = False
+    activity_threshold: int = 10
+    question_state: Optional[QuestionStateManager] = None
+    question_generator: Optional[QuestionGenerator] = None

--- a/cogs/quiz/scheduler.py
+++ b/cogs/quiz/scheduler.py
@@ -24,8 +24,7 @@ class QuizScheduler:
 
         while True:
             cfg = self.bot.quiz_data[self.area]
-            time_window = cfg.get(
-                "time_window", datetime.timedelta(minutes=15))
+            time_window = cfg.time_window
 
             now = datetime.datetime.utcnow()
             window_start = now.replace(second=0, microsecond=0)
@@ -56,7 +55,7 @@ class QuizScheduler:
 
             await asyncio.sleep(max((window_end - datetime.datetime.utcnow()).total_seconds(), 0))
 
-            cid = self.bot.quiz_data[self.area]["channel_id"]
+            cid = self.bot.quiz_data[self.area].channel_id
             self.bot.quiz_cog.awaiting_activity.pop(cid, None)
             if self.area in self.bot.quiz_cog.current_questions:
                 await self.close_question(self.area, timed_out=True)

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -28,7 +28,7 @@ AREA_CONFIG_PATH = "data/pers/quiz/areas.json"
 
 def get_area_by_channel(bot: commands.Bot, channel_id: int) -> Optional[str]:
     for area, cfg in bot.quiz_data.items():
-        if cfg["channel_id"] == channel_id:
+        if cfg.channel_id == channel_id:
             return area
     return None
 
@@ -37,11 +37,11 @@ def save_area_config(bot: commands.Bot):
     out = {}
     for area, cfg in bot.quiz_data.items():
         out[area] = {
-            "channel_id": cfg["channel_id"],
-            "window_timer": int(cfg["time_window"].total_seconds() / 60),
-            "language": cfg["language"],
-            "active": cfg.get("active", False),
-            "activity_threshold": cfg.get("activity_threshold", 10)
+            "channel_id": cfg.channel_id,
+            "window_timer": int(cfg.time_window.total_seconds() / 60),
+            "language": cfg.language,
+            "active": cfg.active,
+            "activity_threshold": cfg.activity_threshold,
         }
     with open(AREA_CONFIG_PATH, "w", encoding="utf-8") as f:
         json.dump(out, f, indent=2, ensure_ascii=False)
@@ -56,7 +56,7 @@ async def time(interaction: discord.Interaction, minutes: app_commands.Range[int
         await interaction.response.send_message("❌ In diesem Channel ist kein Quiz konfiguriert.", ephemeral=True)
         return
 
-    interaction.client.quiz_data[area]["time_window"] = datetime.timedelta(
+    interaction.client.quiz_data[area].time_window = datetime.timedelta(
         minutes=minutes)
     save_area_config(interaction.client)
 
@@ -72,7 +72,7 @@ async def language(interaction: discord.Interaction, lang: Literal["de", "en"]):
         await interaction.response.send_message("❌ In diesem Channel ist kein Quiz konfiguriert.", ephemeral=True)
         return
 
-    interaction.client.quiz_data[area]["language"] = lang
+    interaction.client.quiz_data[area].language = lang
     save_area_config(interaction.client)
 
     await interaction.response.send_message(f"🌐 Sprache für **{area}** auf **{lang}** gesetzt.", ephemeral=True)
@@ -87,7 +87,7 @@ async def threshold(interaction: discord.Interaction, value: app_commands.Range[
         await interaction.response.send_message("❌ In diesem Channel ist kein Quiz konfiguriert.", ephemeral=True)
         return
 
-    interaction.client.quiz_data[area]["activity_threshold"] = value
+    interaction.client.quiz_data[area].activity_threshold = value
     save_area_config(interaction.client)
 
     await interaction.response.send_message(f"📈 Aktivitätsschwelle auf **{value}** gesetzt.", ephemeral=True)
@@ -105,9 +105,9 @@ async def enable(interaction: discord.Interaction, area_name: str, lang: Literal
         return
 
     cfg = interaction.client.quiz_data[area]
-    cfg["channel_id"] = interaction.channel.id
-    cfg["language"] = lang
-    cfg["active"] = True
+    cfg.channel_id = interaction.channel.id
+    cfg.language = lang
+    cfg.active = True
 
     save_area_config(interaction.client)
 
@@ -123,7 +123,7 @@ async def disable(interaction: discord.Interaction):
         return
 
     cfg = interaction.client.quiz_data[area]
-    cfg["active"] = False
+    cfg.active = False
     save_area_config(interaction.client)
 
     await interaction.response.send_message(f"🚫 Quiz für **{area}** deaktiviert.", ephemeral=False)
@@ -138,8 +138,7 @@ async def ask(interaction: discord.Interaction):
         return
 
     quiz_cog: QuizCog = interaction.client.get_cog("QuizCog")
-    time_window = interaction.client.quiz_data[area].get(
-        "time_window", datetime.timedelta(minutes=15))
+    time_window = interaction.client.quiz_data[area].time_window
     end_time = datetime.datetime.utcnow() + time_window
     await quiz_cog.manager.ask_question(area, end_time)
 
@@ -154,7 +153,7 @@ async def duel(interaction: discord.Interaction, punkte: app_commands.Range[int,
         await interaction.response.send_message("❌ In diesem Channel ist kein Quiz konfiguriert.", ephemeral=True)
         return
 
-    qg: QuestionGenerator = interaction.client.quiz_data[area]["question_generator"]
+    qg: QuestionGenerator = interaction.client.quiz_data[area].question_generator
     if modus == "dynamic" and area not in qg.dynamic_providers:
         await interaction.response.send_message("❌ Dieser Modus ist hier nicht verfügbar.", ephemeral=True)
         return
@@ -194,7 +193,7 @@ async def answer(interaction: discord.Interaction):
 
     try:
         channel = interaction.client.get_channel(
-            quiz_cog.bot.quiz_data[area]["channel_id"])
+            quiz_cog.bot.quiz_data[area].channel_id)
         msg = await channel.fetch_message(question_data["message_id"])
         embed = msg.embeds[0]
         embed.color = discord.Color.red()
@@ -242,7 +241,7 @@ async def reset(interaction: discord.Interaction):
         await interaction.response.send_message("❌ Kein Quiz in diesem Channel.", ephemeral=True)
         return
 
-    state = interaction.client.quiz_data[area]["question_state"]
+    state = interaction.client.quiz_data[area].question_state
     state.reset_asked_questions(area)
     await interaction.response.send_message(f"♻️ Frageverlauf für **{area}** wurde zurückgesetzt.", ephemeral=True)
 

--- a/tests/test_load_quiz_config.py
+++ b/tests/test_load_quiz_config.py
@@ -40,10 +40,10 @@ def test_load_quiz_config(tmp_path, monkeypatch):
     load_quiz_config(bot)
 
     assert set(bot.quiz_data.keys()) == {"wcr", "d4"}
-    assert bot.quiz_data["wcr"]["channel_id"] == 1
-    assert bot.quiz_data["d4"]["time_window"] == datetime.timedelta(minutes=10)
-    assert isinstance(bot.quiz_data["wcr"]["question_state"], QuestionStateManager)
-    assert isinstance(bot.quiz_data["wcr"]["question_generator"], QuestionGenerator)
+    assert bot.quiz_data["wcr"].channel_id == 1
+    assert bot.quiz_data["d4"].time_window == datetime.timedelta(minutes=10)
+    assert isinstance(bot.quiz_data["wcr"].question_state, QuestionStateManager)
+    assert isinstance(bot.quiz_data["wcr"].question_generator, QuestionGenerator)
 
 
 def test_single_state_manager(tmp_path, monkeypatch):
@@ -63,6 +63,6 @@ def test_single_state_manager(tmp_path, monkeypatch):
     bot = DummyBot()
     load_quiz_config(bot)
 
-    state1 = bot.quiz_data["wcr"]["question_state"]
-    state2 = bot.quiz_data["d4"]["question_state"]
+    state1 = bot.quiz_data["wcr"].question_state
+    state2 = bot.quiz_data["d4"].question_state
     assert state1 is state2

--- a/tests/test_message_tracker.py
+++ b/tests/test_message_tracker.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from cogs.quiz.message_tracker import MessageTracker
+from cogs.quiz.quiz_config import QuizAreaConfig
 
 
 class DummyAuthor:
@@ -39,7 +40,7 @@ class DummyCog:
 class DummyBot:
     def __init__(self):
         self.quiz_cog = DummyCog()
-        self.quiz_data = {"area1": {"channel_id": 123, "activity_threshold": 3}}
+        self.quiz_data = {"area1": QuizAreaConfig(channel_id=123, activity_threshold=3)}
 
 
 def test_register_message_increments_and_triggers(monkeypatch):

--- a/tests/test_quiz_setup.py
+++ b/tests/test_quiz_setup.py
@@ -21,7 +21,7 @@ async def test_quiz_setup_registers_cog_and_commands(monkeypatch):
 
     bot = MyBot()
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
-    bot.quiz_data = {"questions": {}}
+    bot.quiz_data = {}
 
     await quiz.setup(bot)
 


### PR DESCRIPTION
## Summary
- add new `QuizAreaConfig` dataclass to hold area settings
- adapt `load_quiz_config` to create `QuizAreaConfig` objects
- update quiz modules to use attribute access
- adjust tests for new dataclass

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684056d2e510832f8bf198e094fa4988