### PR TITLE
Add callback for MessageTracker threshold

### DIFF
--- a/cogs/quiz/__init__.py
+++ b/cogs/quiz/__init__.py
@@ -9,7 +9,6 @@ from .question_generator import QuestionGenerator
 from .question_manager import QuestionManager
 from .question_state import QuestionStateManager
 from .question_closer import QuestionCloser
-from .message_tracker import MessageTracker
 from .utils import get_available_areas
 
 logger = get_logger(__name__)
@@ -24,7 +23,6 @@ async def setup(bot: commands.Bot):
 
     areas = get_available_areas()
     state_manager = QuestionStateManager(QUESTION_STATE_PATH)
-    tracker = MessageTracker(bot)
     dynamic_providers = {}
 
     for area in areas:

--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -36,8 +36,8 @@ class QuizCog(commands.Cog):
             QuestionStateManager("data/pers/quiz/question_state.json")
         )
 
-        self.tracker = MessageTracker(bot=self.bot)
         self.manager = QuestionManager(self)
+        self.tracker = MessageTracker(bot=self.bot, on_threshold=self.manager.ask_question)
         self.closer = QuestionCloser(bot=self.bot, state=self.state)
 
         create_logged_task(self.tracker.initialize(), logger)

--- a/cogs/quiz/message_tracker.py
+++ b/cogs/quiz/message_tracker.py
@@ -9,8 +9,9 @@ logger = get_logger(__name__)
 
 
 class MessageTracker:
-    def __init__(self, bot):
+    def __init__(self, bot, on_threshold):
         self.bot = bot
+        self.on_threshold = on_threshold
         self.message_counter = {}
         self.channel_initialized = {}
 
@@ -73,7 +74,7 @@ class MessageTracker:
                     f"[Tracker] Aktivität erreicht in '{area}' ({after}/{threshold}) – Frage wird gestellt."
                 )
                 create_logged_task(
-                    self.bot.quiz_cog.manager.ask_question(
+                    self.on_threshold(
                         area, self.bot.quiz_cog.awaiting_activity[cid][1]
                     ),
                     logger

--- a/tests/test_message_tracker.py
+++ b/tests/test_message_tracker.py
@@ -44,7 +44,7 @@ class DummyBot:
 
 def test_register_message_increments_and_triggers(monkeypatch):
     bot = DummyBot()
-    tracker = MessageTracker(bot)
+    tracker = MessageTracker(bot, bot.quiz_cog.manager.ask_question)
     bot.quiz_cog.awaiting_activity = {123: ("area1", "end")}
 
     triggered = []


### PR DESCRIPTION
## Summary
- make `MessageTracker` take an `on_threshold` callback
- trigger the callback in `register_message`
- pass `QuestionManager.ask_question` to `MessageTracker`
- adapt tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684056bd9940832f9c783027cf731810