### PR TITLE
Apply improvements to champion cog

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -158,6 +158,10 @@ class MyBot(commands.Bot):
         await self.tree.sync(guild=self.main_guild)
 
     async def on_ready(self):
+        if not isinstance(self.main_guild, discord.Guild):
+            guild = self.get_guild(self.main_guild_id)
+            if guild:
+                self.main_guild = guild
         logger.info(
             f"Bot ist bereit! Eingeloggt als {self.user} (ID: {self.user.id})")
 

--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -1,152 +1,11 @@
 import discord
 from discord.ext import commands
-import aiosqlite
-from datetime import datetime
 from typing import Optional
-import os  # Wird nur für os.makedirs in ChampionData gebraucht
 
 from log_setup import get_logger, create_logged_task
+from .data import ChampionData
 
 logger = get_logger(__name__)
-
-
-class ChampionData:
-    """
-    Verwaltet die SQLite-Datenbank für Champion-Punkte und Historie.
-    """
-
-    def __init__(self, db_path: str):
-        self.db_path = db_path
-        self._init_done = False
-
-    async def init_db(self):
-        """
-        Legt Tabellen an, falls sie noch nicht existieren.
-        Wird nur einmal pro Lauf ausgeführt.
-        """
-        if self._init_done:
-            return
-        self._init_done = True
-
-        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
-
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute("""
-                CREATE TABLE IF NOT EXISTS points (
-                    user_id TEXT PRIMARY KEY,
-                    total INTEGER NOT NULL
-                );
-            """)
-            await db.execute("""
-                CREATE TABLE IF NOT EXISTS history (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    user_id TEXT NOT NULL,
-                    delta INTEGER NOT NULL,
-                    reason TEXT NOT NULL,
-                    date TEXT NOT NULL
-                );
-            """)
-            await db.commit()
-
-        logger.info("[ChampionData] SQLite‐Datenbank initialisiert.")
-
-    async def get_total(self, user_id: str) -> int:
-        await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?", (user_id,)
-            )
-            row = await cur.fetchone()
-            return row[0] if row else 0
-
-    async def add_delta(self, user_id: str, delta: int, reason: str) -> int:
-        await self.init_db()
-        now = datetime.utcnow().isoformat()
-
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?", (user_id,)
-            )
-            row = await cur.fetchone()
-            current_total = row[0] if row else 0
-
-            new_total = current_total + delta
-            if row:
-                await db.execute(
-                    "UPDATE points SET total = ? WHERE user_id = ?",
-                    (new_total, user_id)
-                )
-            else:
-                await db.execute(
-                    "INSERT INTO points(user_id, total) VALUES (?, ?)",
-                    (user_id, new_total)
-                )
-
-            await db.execute(
-                "INSERT INTO history(user_id, delta, reason, date) VALUES (?, ?, ?, ?)",
-                (user_id, delta, reason, now)
-            )
-
-            await db.commit()
-
-        logger.info(
-            f"[ChampionData] {user_id} Punkte geändert um {delta} ({reason}). Neuer Total: {new_total}."
-        )
-        return new_total
-
-    async def get_history(self, user_id: str, limit: int = 10) -> list[dict]:
-        await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                """
-                SELECT delta, reason, date
-                  FROM history
-                 WHERE user_id = ?
-                 ORDER BY date DESC
-                 LIMIT ?
-                """,
-                (user_id, limit)
-            )
-            rows = await cur.fetchall()
-
-        return [{"delta": r[0], "reason": r[1], "date": r[2]} for r in rows]
-
-    async def get_leaderboard(self, limit: int = 10, offset: int = 0) -> list[tuple[str, int]]:
-        await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                """
-                SELECT user_id, total
-                  FROM points
-                 ORDER BY total DESC
-                 LIMIT ? OFFSET ?
-                """,
-                (limit, offset)
-            )
-            rows = await cur.fetchall()
-
-        return [(r[0], r[1]) for r in rows]
-
-    async def get_rank(self, user_id: str) -> Optional[tuple[int, int]]:
-        await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?",
-                (user_id,),
-            )
-            row = await cur.fetchone()
-            if not row:
-                return None
-            total = row[0]
-
-            cur = await db.execute(
-                "SELECT COUNT(*) FROM points WHERE total > ?",
-                (total,),
-            )
-            count_row = await cur.fetchone()
-            rank = count_row[0] + 1
-
-        return rank, total
 
 
 class ChampionCog(commands.Cog):
@@ -184,8 +43,8 @@ class ChampionCog(commands.Cog):
 
     async def _apply_champion_role(self, user_id_str: str, score: int):
         # Zugriff auf Guild NUR noch über self.bot.main_guild (Zentral, wie in bot.py gesetzt)
-        guild = discord.utils.get(self.bot.guilds, id=self.bot.main_guild.id)
-        if not guild:
+        guild = self.bot.main_guild
+        if not isinstance(guild, discord.Guild):
             logger.warning("[ChampionCog] Guild nicht gefunden.")
             return
 

--- a/cogs/champion/data.py
+++ b/cogs/champion/data.py
@@ -1,0 +1,148 @@
+import aiosqlite
+from datetime import datetime
+from typing import Optional
+import os
+
+from log_setup import get_logger
+
+logger = get_logger(__name__)
+
+
+class ChampionData:
+    """Verwaltet die SQLite-Datenbank für Champion-Punkte und Historie."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._init_done = False
+
+    async def init_db(self):
+        """Legt Tabellen an, falls sie noch nicht existieren."""
+        if self._init_done:
+            return
+        self._init_done = True
+
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS points (
+                    user_id TEXT PRIMARY KEY,
+                    total INTEGER NOT NULL
+                );
+                """
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    delta INTEGER NOT NULL,
+                    reason TEXT NOT NULL,
+                    date TEXT NOT NULL
+                );
+                """
+            )
+            await db.commit()
+
+        logger.info("[ChampionData] SQLite‐Datenbank initialisiert.")
+
+    async def get_total(self, user_id: str) -> int:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                "SELECT total FROM points WHERE user_id = ?",
+                (user_id,),
+            )
+            row = await cur.fetchone()
+            return row[0] if row else 0
+
+    async def add_delta(self, user_id: str, delta: int, reason: str) -> int:
+        await self.init_db()
+        now = datetime.utcnow().isoformat()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                "SELECT total FROM points WHERE user_id = ?",
+                (user_id,),
+            )
+            row = await cur.fetchone()
+            current_total = row[0] if row else 0
+
+            new_total = current_total + delta
+            if row:
+                await db.execute(
+                    "UPDATE points SET total = ? WHERE user_id = ?",
+                    (new_total, user_id),
+                )
+            else:
+                await db.execute(
+                    "INSERT INTO points(user_id, total) VALUES (?, ?)",
+                    (user_id, new_total),
+                )
+
+            await db.execute(
+                "INSERT INTO history(user_id, delta, reason, date) VALUES (?, ?, ?, ?)",
+                (user_id, delta, reason, now),
+            )
+
+            await db.commit()
+
+        logger.info(
+            f"[ChampionData] {user_id} Punkte geändert um {delta} ({reason}). Neuer Total: {new_total}."
+        )
+        return new_total
+
+    async def get_history(self, user_id: str, limit: int = 10) -> list[dict]:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                """
+                SELECT delta, reason, date
+                  FROM history
+                 WHERE user_id = ?
+                 ORDER BY date DESC
+                 LIMIT ?
+                """,
+                (user_id, limit),
+            )
+            rows = await cur.fetchall()
+
+        return [{"delta": r[0], "reason": r[1], "date": r[2]} for r in rows]
+
+    async def get_leaderboard(self, limit: int = 10, offset: int = 0) -> list[tuple[str, int]]:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                """
+                SELECT user_id, total
+                  FROM points
+                 ORDER BY total DESC
+                 LIMIT ? OFFSET ?
+                """,
+                (limit, offset),
+            )
+            rows = await cur.fetchall()
+
+        return [(r[0], r[1]) for r in rows]
+
+    async def get_rank(self, user_id: str) -> Optional[tuple[int, int]]:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                "SELECT total FROM points WHERE user_id = ?",
+                (user_id,),
+            )
+            row = await cur.fetchone()
+            if not row:
+                return None
+            total = row[0]
+
+            cur = await db.execute(
+                "SELECT COUNT(*) FROM points WHERE total > ?",
+                (total,),
+            )
+            count_row = await cur.fetchone()
+            rank = count_row[0] + 1
+
+        return rank, total

--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -2,6 +2,7 @@ import discord
 from discord import app_commands
 
 from log_setup import get_logger
+from permissions import moderator_only
 from .cog import ChampionCog
 
 logger = get_logger(__name__)
@@ -13,11 +14,9 @@ champion_group = app_commands.Group(
 
 
 @champion_group.command(name="give", description="Gibt einem User Punkte (nur Mods)")
+@moderator_only()
 @app_commands.describe(user="Der Nutzer, dem Punkte gegeben werden", punkte="Anzahl der Punkte", grund="Begründung")
 async def give(interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str):
-    if not interaction.user.guild_permissions.manage_guild:
-        await interaction.response.send_message("❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True)
-        return
 
     logger.info(
         f"/champion give by {interaction.user} -> {user} ({punkte} Punkte, Grund: {grund})"
@@ -29,11 +28,9 @@ async def give(interaction: discord.Interaction, user: discord.Member, punkte: i
 
 
 @champion_group.command(name="remove", description="Entfernt Punkte (nur Mods)")
+@moderator_only()
 @app_commands.describe(user="Der Nutzer, von dem Punkte abgezogen werden", punkte="Anzahl der Punkte", grund="Begründung")
 async def remove(interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str):
-    if not interaction.user.guild_permissions.manage_guild:
-        await interaction.response.send_message("❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True)
-        return
 
     logger.info(
         f"/champion remove by {interaction.user} -> {user} ({punkte} Punkte, Grund: {grund})"
@@ -45,11 +42,9 @@ async def remove(interaction: discord.Interaction, user: discord.Member, punkte:
 
 
 @champion_group.command(name="set", description="Setzt die Punktzahl eines Users (nur Mods)")
+@moderator_only()
 @app_commands.describe(user="Der Nutzer, dessen Punktzahl gesetzt wird", punkte="Neue Gesamtpunktzahl", grund="Begründung")
 async def set_points(interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str):
-    if not interaction.user.guild_permissions.manage_guild:
-        await interaction.response.send_message("❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True)
-        return
 
     logger.info(
         f"/champion set by {interaction.user} -> {user} ({punkte} Punkte, Grund: {grund})"
@@ -63,11 +58,9 @@ async def set_points(interaction: discord.Interaction, user: discord.Member, pun
 
 
 @champion_group.command(name="reset", description="Setzt die Punkte eines Nutzers auf 0 (nur Mods)")
+@moderator_only()
 @app_commands.describe(user="Der Nutzer, dessen Punkte zurückgesetzt werden")
 async def reset(interaction: discord.Interaction, user: discord.Member):
-    if not interaction.user.guild_permissions.manage_guild:
-        await interaction.response.send_message("❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True)
-        return
 
     logger.info(f"/champion reset by {interaction.user} for {user}")
 
@@ -118,12 +111,10 @@ async def myhistory(interaction: discord.Interaction):
 
 
 @champion_group.command(name="history", description="Zeigt die Punkte-Historie eines Spielers")
+@moderator_only()
 @app_commands.describe(user="Der Spieler, dessen Historie angezeigt wird")
 async def history(interaction: discord.Interaction, user: discord.Member):
     logger.info(f"/champion history by {interaction.user} target={user}")
-    if not interaction.user.guild_permissions.manage_guild:
-        await interaction.response.send_message("❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True)
-        return
 
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     user_id_str = str(user.id)

--- a/permissions.py
+++ b/permissions.py
@@ -1,0 +1,13 @@
+from discord import app_commands, Interaction
+
+
+def moderator_only():
+    async def predicate(interaction: Interaction) -> bool:
+        if interaction.user.guild_permissions.manage_guild:
+            return True
+        await interaction.response.send_message(
+            "❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True
+        )
+        return False
+
+    return app_commands.check(predicate)

--- a/tests/test_champion_cog.py
+++ b/tests/test_champion_cog.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cogs.champion.cog import ChampionCog
+from cogs.champion.data import ChampionData
+
+
+class DummyBot:
+    def __init__(self):
+        self.data = {"champion": {"roles": []}}
+        self.main_guild = None
+        self.guilds = []
+
+
+@pytest.mark.asyncio
+async def test_update_user_score_saves_and_calls(monkeypatch, tmp_path):
+    bot = DummyBot()
+    cog = ChampionCog(bot)
+    cog.data = ChampionData(str(tmp_path / "points.db"))
+
+    called = []
+
+    async def fake_apply(user_id, score):
+        called.append((user_id, score))
+
+    def fake_task(coro, logger):
+        asyncio.create_task(coro)
+
+    monkeypatch.setattr("cogs.champion.cog.create_logged_task", fake_task)
+    monkeypatch.setattr(cog, "_apply_champion_role", fake_apply)
+
+    total = await cog.update_user_score(123, 5, "test")
+    await asyncio.sleep(0)
+    assert total == 5
+    assert called == [("123", 5)]
+
+
+def test_get_current_role():
+    bot = DummyBot()
+    bot.data["champion"]["roles"] = [
+        {"name": "Gold", "threshold": 50},
+        {"name": "Silver", "threshold": 20},
+    ]
+    cog = ChampionCog(bot)
+
+    assert cog.get_current_role(55) == "Gold"
+    assert cog.get_current_role(25) == "Silver"
+    assert cog.get_current_role(10) is None

--- a/tests/test_champion_data.py
+++ b/tests/test_champion_data.py
@@ -5,7 +5,7 @@ import pytest
 # Add the project root to sys.path so that `cogs` can be imported
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from cogs.champion.cog import ChampionData
+from cogs.champion.data import ChampionData
 
 @pytest.mark.asyncio
 async def test_add_and_get_total(tmp_path):


### PR DESCRIPTION
## Summary
- extract `ChampionData` to its own module
- add reusable `moderator_only` permission check
- store guild object once and reuse in champion cog
- refactor champion slash commands to use permission decorator
- add tests for champion cog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405520bbfc832fae659e83603e7361