### PR TITLE
Fix duplicate quiz question manager methods

### DIFF
--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -15,10 +15,9 @@ class QuestionManager:
         self.cog = cog
         self.bot = cog.bot
 
-    async def prepare_question(self, area: str, end_time: datetime.datetime):
-        logger = get_logger(__name__, area=area)
     async def prepare_question(self, area: str, end_time: datetime.datetime) -> None:
         """Check conditions and schedule a question for ``area``."""
+        logger = get_logger(__name__, area=area)
         cfg = self.bot.quiz_data[area]
 
         if not cfg.active:
@@ -55,10 +54,9 @@ class QuestionManager:
             f"[QuestionManager] Bedingungen erfüllt – sende Frage für '{area}'.")
         await self.ask_question(area, end_time)
 
-    async def ask_question(self, area: str, end_time: datetime.datetime):
-        logger = get_logger(__name__, area=area)
     async def ask_question(self, area: str, end_time: datetime.datetime) -> None:
         """Post a question immediately and store its state."""
+        logger = get_logger(__name__, area=area)
         cfg = self.bot.quiz_data[area]
         channel = self.bot.get_channel(cfg.channel_id)
         qg = cfg.question_generator


### PR DESCRIPTION
## Summary
- remove stray partial definitions of `prepare_question` and `ask_question`
- define the logger inside each method

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840682c8adc832f842608200d25aef6