### PR TITLE
Refund duel points when no question

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -161,6 +161,12 @@ class QuizDuelGame:
             question = qg.generate(self.area)
             if not question:
                 await self.thread.send("Keine Frage generiert. Duell abgebrochen.")
+                champion_cog = self.cog.bot.get_cog("ChampionCog")
+                if champion_cog:
+                    await champion_cog.update_user_score(
+                        self.challenger.id, self.points, "Quiz-Duell Rückgabe"
+                    )
+                await self.thread.edit(archived=True)
                 return
             answers = question["antwort"] if isinstance(question["antwort"], list) else [question["antwort"]]
             embed = discord.Embed(title=f"Runde {rnd}", description=question["frage"], color=discord.Color.blue())


### PR DESCRIPTION
## Summary
- return challenger points when no duel question is generated

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bca34184832f8fd4760285257765