### PR TITLE
Add final score message to duel finish

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -199,4 +199,7 @@ class QuizDuelGame:
         else:
             await champion_cog.update_user_score(self.challenger.id, self.points, "Quiz-Duell Rückgabe")
             await self.thread.send("Unentschieden. Einsatz zurück an Herausforderer.")
+        await self.thread.send(
+            f"Endstand: {self.challenger.display_name} {self.scores[self.challenger.id]} - {self.scores[self.opponent.id]} {self.opponent.display_name}"
+        )
         await self.thread.edit(archived=True)


### PR DESCRIPTION
## Summary
- print the final score for both players in `QuizDuelGame._finish`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bca73094832f89371b4522735036