### PR TITLE
Improve champion data handling and simplify questions

### DIFF
--- a/cogs/champion/data.py
+++ b/cogs/champion/data.py
@@ -13,84 +13,95 @@ class ChampionData:
 
     def __init__(self, db_path: str):
         self.db_path = db_path
+        self.db: aiosqlite.Connection | None = None
         self._init_done = False
+
+    async def _get_db(self) -> aiosqlite.Connection:
+        if self.db is None:
+            os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+            self.db = await aiosqlite.connect(self.db_path)
+            await self.db.execute("PRAGMA journal_mode=WAL")
+        return self.db
 
     async def init_db(self):
         """Legt Tabellen an, falls sie noch nicht existieren."""
         if self._init_done:
             return
+        db = await self._get_db()
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS points (
+                user_id TEXT PRIMARY KEY,
+                total INTEGER NOT NULL
+            );
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                delta INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                date TEXT NOT NULL
+            );
+            """
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_points_total ON points(total)"
+        )
+        await db.commit()
         self._init_done = True
-
-        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
-
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS points (
-                    user_id TEXT PRIMARY KEY,
-                    total INTEGER NOT NULL
-                );
-                """
-            )
-            await db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS history (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    user_id TEXT NOT NULL,
-                    delta INTEGER NOT NULL,
-                    reason TEXT NOT NULL,
-                    date TEXT NOT NULL
-                );
-                """
-            )
-            await db.commit()
 
         logger.info("[ChampionData] SQLite‐Datenbank initialisiert.")
 
     async def close(self) -> None:
-        """Compatibility method for API parity."""
-        return None
+        """Close the database connection."""
+        if self.db is not None:
+            await self.db.close()
+            self.db = None
+            self._init_done = False
 
     async def get_total(self, user_id: str) -> int:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?",
-                (user_id,),
-            )
-            row = await cur.fetchone()
-            return row[0] if row else 0
+        db = await self._get_db()
+        cur = await db.execute(
+            "SELECT total FROM points WHERE user_id = ?",
+            (user_id,),
+        )
+        row = await cur.fetchone()
+        return row[0] if row else 0
 
     async def add_delta(self, user_id: str, delta: int, reason: str) -> int:
         await self.init_db()
         now = datetime.utcnow().isoformat()
 
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?",
-                (user_id,),
-            )
-            row = await cur.fetchone()
-            current_total = row[0] if row else 0
+        db = await self._get_db()
+        cur = await db.execute(
+            "SELECT total FROM points WHERE user_id = ?",
+            (user_id,),
+        )
+        row = await cur.fetchone()
+        current_total = row[0] if row else 0
 
-            new_total = current_total + delta
-            if row:
-                await db.execute(
-                    "UPDATE points SET total = ? WHERE user_id = ?",
-                    (new_total, user_id),
-                )
-            else:
-                await db.execute(
-                    "INSERT INTO points(user_id, total) VALUES (?, ?)",
-                    (user_id, new_total),
-                )
-
+        new_total = current_total + delta
+        if row:
             await db.execute(
-                "INSERT INTO history(user_id, delta, reason, date) VALUES (?, ?, ?, ?)",
-                (user_id, delta, reason, now),
+                "UPDATE points SET total = ? WHERE user_id = ?",
+                (new_total, user_id),
+            )
+        else:
+            await db.execute(
+                "INSERT INTO points(user_id, total) VALUES (?, ?)",
+                (user_id, new_total),
             )
 
-            await db.commit()
+        await db.execute(
+            "INSERT INTO history(user_id, delta, reason, date) VALUES (?, ?, ?, ?)",
+            (user_id, delta, reason, now),
+        )
+
+        await db.commit()
 
         logger.info(
             f"[ChampionData] {user_id} Punkte geändert um {delta} ({reason}). Neuer Total: {new_total}."
@@ -99,54 +110,54 @@ class ChampionData:
 
     async def get_history(self, user_id: str, limit: int = 10) -> list[dict]:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                """
-                SELECT delta, reason, date
-                  FROM history
-                 WHERE user_id = ?
-                 ORDER BY date DESC
-                 LIMIT ?
-                """,
-                (user_id, limit),
-            )
-            rows = await cur.fetchall()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT delta, reason, date
+              FROM history
+             WHERE user_id = ?
+             ORDER BY date DESC
+             LIMIT ?
+            """,
+            (user_id, limit),
+        )
+        rows = await cur.fetchall()
 
         return [{"delta": r[0], "reason": r[1], "date": r[2]} for r in rows]
 
     async def get_leaderboard(self, limit: int = 10, offset: int = 0) -> list[tuple[str, int]]:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                """
-                SELECT user_id, total
-                  FROM points
-                 ORDER BY total DESC
-                 LIMIT ? OFFSET ?
-                """,
-                (limit, offset),
-            )
-            rows = await cur.fetchall()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT user_id, total
+              FROM points
+             ORDER BY total DESC
+             LIMIT ? OFFSET ?
+            """,
+            (limit, offset),
+        )
+        rows = await cur.fetchall()
 
         return [(r[0], r[1]) for r in rows]
 
     async def get_rank(self, user_id: str) -> Optional[tuple[int, int]]:
         await self.init_db()
-        async with aiosqlite.connect(self.db_path) as db:
-            cur = await db.execute(
-                "SELECT total FROM points WHERE user_id = ?",
-                (user_id,),
-            )
-            row = await cur.fetchone()
-            if not row:
-                return None
-            total = row[0]
+        db = await self._get_db()
+        cur = await db.execute(
+            "SELECT total FROM points WHERE user_id = ?",
+            (user_id,),
+        )
+        row = await cur.fetchone()
+        if not row:
+            return None
+        total = row[0]
 
-            cur = await db.execute(
-                "SELECT COUNT(*) FROM points WHERE total > ?",
-                (total,),
-            )
-            count_row = await cur.fetchone()
-            rank = count_row[0] + 1
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM points WHERE total > ?",
+            (total,),
+        )
+        count_row = await cur.fetchone()
+        rank = count_row[0] + 1
 
         return rank, total

--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -36,15 +36,6 @@ class QuestionGenerator:
                 f"[QuestionGenerator] Dynamische Frage für '{area}': {len(questions)}")
         else:
             questions = self.questions_by_area.get(language, {}).get(area, [])
-            if isinstance(questions, dict):
-                flat = []
-                for category, qs in questions.items():
-                    for q in qs:
-                        if isinstance(q, dict):
-                            q = q.copy()
-                            q.setdefault("category", category)
-                        flat.append(q)
-                questions = flat
             logger.debug(
                 f"[QuestionGenerator] Statische Fragen für '{area}': {len(questions)}")
 

--- a/data/quiz/questions_de.json
+++ b/data/quiz/questions_de.json
@@ -1,62 +1,54 @@
 {
-  "wcr": {
-    "Lore": [
-      {
-        "id": 1,
-        "frage": "Wer ist der Hauptantagonist in Warcraft Rumble?",
-        "antwort": "Morton der Unbezwingbare"
-      }
-    ],
-    "Mechanik": [
-      {
-        "id": 2,
-        "frage": "Welche Einheit wird oft als „Tank“ bezeichnet?",
-        "antwort": "Golem"
-      }
-    ],
-    "Franchise": [
-      {
-        "id": 3,
-        "frage": "In welchem Jahr wurde Warcraft Rumble veröffentlicht?",
-        "antwort": "2023"
-      }
-    ],
-    "Welt": [
-      {
-        "id": 4,
-        "frage": "In welchem Gebiet kämpft man gegen Hogger?",
-        "antwort": "Elwynn Forest"
-      }
-    ]
-  },
-  "d4": {
-    "Lore": [
-      {
-        "id": 1,
-        "frage": "Wer ist der Hauptantagonist in Diablo IV?",
-        "antwort": "Lilith"
-      }
-    ],
-    "Mechanik": [
-      {
-        "id": 2,
-        "frage": "Welche Klasse kann als Werwolf kämpfen?",
-        "antwort": "Druide"
-      }
-    ],
-    "Franchise": [
-      {
-        "id": 3,
-        "frage": "In welchem Jahr erschien Diablo IV?",
-        "antwort": "2023"
-      }
-    ],
-    "Welt": [
-      {
-        "id": 4,
-        "frage": "Wie heißt die Stadt, die als Hauptquartier dient?",
-        "antwort": "Kyovashad"
-      }
-    ]
-  }
+  "wcr": [
+    {
+      "id": 1,
+      "frage": "Wer ist der Hauptantagonist in Warcraft Rumble?",
+      "antwort": "Morton der Unbezwingbare",
+      "category": "Lore"
+    },
+    {
+      "id": 2,
+      "frage": "Welche Einheit wird oft als „Tank“ bezeichnet?",
+      "antwort": "Golem",
+      "category": "Mechanik"
+    },
+    {
+      "id": 3,
+      "frage": "In welchem Jahr wurde Warcraft Rumble veröffentlicht?",
+      "antwort": "2023",
+      "category": "Franchise"
+    },
+    {
+      "id": 4,
+      "frage": "In welchem Gebiet kämpft man gegen Hogger?",
+      "antwort": "Elwynn Forest",
+      "category": "Welt"
+    }
+  ],
+  "d4": [
+    {
+      "id": 1,
+      "frage": "Wer ist der Hauptantagonist in Diablo IV?",
+      "antwort": "Lilith",
+      "category": "Lore"
+    },
+    {
+      "id": 2,
+      "frage": "Welche Klasse kann als Werwolf kämpfen?",
+      "antwort": "Druide",
+      "category": "Mechanik"
+    },
+    {
+      "id": 3,
+      "frage": "In welchem Jahr erschien Diablo IV?",
+      "antwort": "2023",
+      "category": "Franchise"
+    },
+    {
+      "id": 4,
+      "frage": "Wie heißt die Stadt, die als Hauptquartier dient?",
+      "antwort": "Kyovashad",
+      "category": "Welt"
+    }
+  ]
 }

--- a/data/quiz/questions_en.json
+++ b/data/quiz/questions_en.json
@@ -1,62 +1,54 @@
 {
-  "wcr": {
-    "Lore": [
-      {
-        "id": 1,
-        "frage": "Who is the main antagonist in Warcraft Rumble?",
-        "antwort": "Morton the Unyielding"
-      }
-    ],
-    "Mechanik": [
-      {
-        "id": 2,
-        "frage": "Which unit is often referred to as a 'Tank'?",
-        "antwort": "Golem"
-      }
-    ],
-    "Franchise": [
-      {
-        "id": 3,
-        "frage": "In which year was Warcraft Rumble released?",
-        "antwort": "2023"
-      }
-    ],
-    "Welt": [
-      {
-        "id": 4,
-        "frage": "In which area do you fight Hogger?",
-        "antwort": "Elwynn Forest"
-      }
-    ]
-  },
-  "d4": {
-    "Lore": [
-      {
-        "id": 1,
-        "frage": "Who is the main antagonist in Diablo IV?",
-        "antwort": "Lilith"
-      }
-    ],
-    "Mechanik": [
-      {
-        "id": 2,
-        "frage": "Which class can fight as a Werewolf?",
-        "antwort": "Druid"
-      }
-    ],
-    "Franchise": [
-      {
-        "id": 3,
-        "frage": "In which year was Diablo IV released?",
-        "antwort": "2023"
-      }
-    ],
-    "Welt": [
-      {
-        "id": 4,
-        "frage": "What is the name of the city that serves as the headquarters?",
-        "antwort": "Kyovashad"
-      }
-    ]
-  }
+  "wcr": [
+    {
+      "id": 1,
+      "frage": "Who is the main antagonist in Warcraft Rumble?",
+      "antwort": "Morton the Unyielding",
+      "category": "Lore"
+    },
+    {
+      "id": 2,
+      "frage": "Which unit is often referred to as a 'Tank'?",
+      "antwort": "Golem",
+      "category": "Mechanik"
+    },
+    {
+      "id": 3,
+      "frage": "In which year was Warcraft Rumble released?",
+      "antwort": "2023",
+      "category": "Franchise"
+    },
+    {
+      "id": 4,
+      "frage": "In which area do you fight Hogger?",
+      "antwort": "Elwynn Forest",
+      "category": "Welt"
+    }
+  ],
+  "d4": [
+    {
+      "id": 1,
+      "frage": "Who is the main antagonist in Diablo IV?",
+      "antwort": "Lilith",
+      "category": "Lore"
+    },
+    {
+      "id": 2,
+      "frage": "Which class can fight as a Werewolf?",
+      "antwort": "Druid",
+      "category": "Mechanik"
+    },
+    {
+      "id": 3,
+      "frage": "In which year was Diablo IV released?",
+      "antwort": "2023",
+      "category": "Franchise"
+    },
+    {
+      "id": 4,
+      "frage": "What is the name of the city that serves as the headquarters?",
+      "antwort": "Kyovashad",
+      "category": "Welt"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- keep a persistent aiosqlite connection for champion points
- enable WAL mode and add an index on scores
- simplify question generator by expecting already flattened lists
- store quiz questions in a flat list with `category` field

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415feff828832f8a8daa094bf839f1