### PR TITLE
Implement dynamic duel mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Persistente Dateien wie Punktedatenbank oder Fragehistorie werden zur Laufzeit i
 /quiz enable           # Quiz aktivieren (Area, Sprache)
 /quiz language         # Sprache des Quiz ändern
 /quiz time             # Zeitfenster konfigurieren
-/quiz duel             # Quiz-Duell starten
+/quiz duel             # Quiz-Duell starten (bo3, bo5 oder dynamic)
 /quiz threshold        # Nachrichtenschwelle
 /quiz reset            # Fragehistorie zurücksetzen
 ```

--- a/cogs/quiz/area_providers/base.py
+++ b/cogs/quiz/area_providers/base.py
@@ -13,3 +13,15 @@ class DynamicQuestionProvider(ABC):
     def generate(self) -> Optional[Dict]:
         """Generiert eine einzelne Frage."""
         pass
+
+    def generate_all_types(self) -> list[Dict]:
+        """Return one question for every generic type if available."""
+        questions = []
+        for attr in dir(self):
+            if attr.startswith("generate_type_"):
+                func = getattr(self, attr)
+                if callable(func):
+                    q = func()
+                    if q:
+                        questions.append(q)
+        return questions

--- a/cogs/quiz/area_providers/wcr.py
+++ b/cogs/quiz/area_providers/wcr.py
@@ -53,6 +53,21 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         logger.info(f"[WCRQuestionProvider] Generated: {question['frage']}")
         return question
 
+    def generate_all_types(self) -> list[dict]:
+        """Generate one question for every available type."""
+        questions = []
+        for func in [
+            self.generate_type_1,
+            self.generate_type_2,
+            self.generate_type_3,
+            self.generate_type_4,
+            self.generate_type_5,
+        ]:
+            q = func()
+            if q:
+                questions.append(q)
+        return questions
+
     def generate_type_1(self):
         talents = []
         for unit in self.units:

--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -215,6 +215,7 @@ class QuizDuelGame:
         self.pot = pot
         self.stake = pot // 2
         self.scores = {challenger.id: 0, opponent.id: 0}
+        self.winner_id: int | None = None
 
     async def run(self) -> None:
         """Run the duel until one player has enough wins."""
@@ -224,6 +225,63 @@ class QuizDuelGame:
         logger.info(
             f"QuizDuelGame started between {self.challenger} and {self.opponent} mode={self.mode} rounds={total_rounds}"
         )
+
+        if self.mode == "dynamic":
+            provider = qg.get_dynamic_provider(self.area)
+            if not provider:
+                await self.thread.send("Keine Frage generiert. Duell abgebrochen.")
+                await self.thread.edit(archived=True)
+                return
+            questions = provider.generate_all_types()
+            if not questions:
+                await self.thread.send("Keine Frage generiert. Duell abgebrochen.")
+                champion_cog = self.cog.bot.get_cog("ChampionCog")
+                if champion_cog:
+                    await champion_cog.update_user_score(self.challenger.id, self.stake, "Quiz-Duell Rückgabe")
+                    await champion_cog.update_user_score(self.opponent.id, self.stake, "Quiz-Duell Rückgabe")
+                await self.thread.edit(archived=True)
+                return
+
+            views: list[DuelQuestionView] = []
+            for idx, question in enumerate(questions, start=1):
+                answers = question["antwort"] if isinstance(question["antwort"], list) else [question["antwort"]]
+                embed = discord.Embed(title=f"Frage {idx}", description=question["frage"], color=discord.Color.blue())
+                view = DuelQuestionView(self.challenger, self.opponent, answers)
+                msg = await self.thread.send(embed=embed, view=view)
+                view.message = msg
+                views.append(view)
+
+            for v in views:
+                await v.wait()
+
+            last_correct: dict[int, datetime.datetime | None] = {self.challenger.id: None, self.opponent.id: None}
+            for v in views:
+                for uid, (answer, ts) in v.responses.items():
+                    if check_answer(answer, v.correct_answers):
+                        self.scores[uid] += 1
+                        if last_correct[uid] is None or ts > last_correct[uid]:
+                            last_correct[uid] = ts
+
+            c_score = self.scores[self.challenger.id]
+            o_score = self.scores[self.opponent.id]
+
+            if c_score == o_score:
+                t1 = last_correct[self.challenger.id]
+                t2 = last_correct[self.opponent.id]
+                if t1 and t2:
+                    if t1 < t2:
+                        self.winner_id = self.challenger.id
+                    elif t2 < t1:
+                        self.winner_id = self.opponent.id
+            elif c_score > o_score:
+                self.winner_id = self.challenger.id
+            else:
+                self.winner_id = self.opponent.id
+
+            await self._finish()
+            return
+
+        # classic sequential modes
         for rnd in range(1, total_rounds + 1):
             question = qg.generate(self.area)
             if not question:
@@ -275,7 +333,9 @@ class QuizDuelGame:
         opponent_score = self.scores[self.opponent.id]
         winner: discord.Member | None = None
 
-        if challenger_score > opponent_score:
+        if self.winner_id:
+            winner = self.challenger if self.winner_id == self.challenger.id else self.opponent
+        elif challenger_score > opponent_score:
             winner = self.challenger
         elif opponent_score > challenger_score:
             winner = self.opponent

--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -22,6 +22,10 @@ class QuestionGenerator:
         self.dynamic_providers = dynamic_providers
         logger.info("[QuestionGenerator] QuestionGenerator initialized.")
 
+    def get_dynamic_provider(self, area: str) -> DynamicQuestionProvider | None:
+        """Return the dynamic provider for ``area`` if available."""
+        return self.dynamic_providers.get(area)
+
     def generate(self, area: str | None = None, language: str = "de") -> Dict[str, Any] | None:
         """Generate a new question for ``area`` in the given ``language``."""
         if not area:

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -145,7 +145,7 @@ async def ask(interaction: discord.Interaction):
 
 
 @quiz_group.command(name="duel", description="Starte ein Quiz-Duell")
-@app_commands.describe(punkte="Gesetzte Punkte", modus="Modus des Duells")
+@app_commands.describe(punkte="Gesetzte Punkte", modus="Modus des Duells (bo3, bo5 oder dynamic)")
 async def duel(interaction: discord.Interaction, punkte: app_commands.Range[int, 1, 10000], modus: Literal["bo3", "bo5", "dynamic"] = "bo3"):
     area = get_area_by_channel(interaction.client, interaction.channel.id)
     if not area:

--- a/tests/test_question_generator.py
+++ b/tests/test_question_generator.py
@@ -47,3 +47,11 @@ def test_generate_handles_missing_area(monkeypatch):
 
     assert gen.generate("missing") is None
     assert gen.generate(None) is None
+
+
+def test_get_dynamic_provider():
+    state = DummyStateManager()
+    provider = object()
+    gen = QuestionGenerator({"de": {}}, state, {"area": provider})
+    assert gen.get_dynamic_provider("area") is provider
+    assert gen.get_dynamic_provider("missing") is None

--- a/tests/test_wcr_question_provider.py
+++ b/tests/test_wcr_question_provider.py
@@ -70,3 +70,16 @@ def test_generate_type_5(monkeypatch):
     q = provider.generate_type_5()
     assert q is not None
     assert "frage" in q and "antwort" in q and "id" in q
+
+
+def test_generate_all_types(monkeypatch):
+    provider = create_provider()
+
+    monkeypatch.setattr(provider, "generate_type_1", lambda: {"frage": "f1", "antwort": "a", "id": 1})
+    monkeypatch.setattr(provider, "generate_type_2", lambda: {"frage": "f2", "antwort": "b", "id": 2})
+    monkeypatch.setattr(provider, "generate_type_3", lambda: {"frage": "f3", "antwort": "c", "id": 3})
+    monkeypatch.setattr(provider, "generate_type_4", lambda: {"frage": "f4", "antwort": "d", "id": 4})
+    monkeypatch.setattr(provider, "generate_type_5", lambda: {"frage": "f5", "antwort": "e", "id": 5})
+
+    qs = provider.generate_all_types()
+    assert [q["id"] for q in qs] == [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary
- extend base question provider with `generate_all_types`
- implement `generate_all_types` for Warcraft Rumble provider
- add helper `get_dynamic_provider` in `QuestionGenerator`
- support dynamic duel mode in `QuizDuelGame`
- describe dynamic duel mode in README and slash command help
- test coverage for new provider methods

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416c62b6cc832fadb5f1a207c2e1ac