### PR TITLE
Fix leaderboard emoji and add clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Persistente Dateien wie Punktedatenbank oder Fragehistorie werden zur Laufzeit i
 /champion leaderboard  # Rangliste
 /champion roles        # Rollen-Schwellen
 /champion rank         # Rang eines Users
+/champion clean        # Entfernt Daten ehemaliger Mitglieder
 ```
 
 ### Quiz

--- a/cogs/champion/data.py
+++ b/cogs/champion/data.py
@@ -161,3 +161,20 @@ class ChampionData:
         rank = count_row[0] + 1
 
         return rank, total
+
+    async def delete_user(self, user_id: str) -> None:
+        """Remove all data for ``user_id`` from the database."""
+        await self.init_db()
+        db = await self._get_db()
+        await db.execute("DELETE FROM points WHERE user_id = ?", (user_id,))
+        await db.execute("DELETE FROM history WHERE user_id = ?", (user_id,))
+        await db.commit()
+        logger.info(f"[ChampionData] Eintrag {user_id} entfernt.")
+
+    async def get_all_user_ids(self) -> list[str]:
+        """Return a list of all user IDs stored in the points table."""
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute("SELECT user_id FROM points")
+        rows = await cur.fetchall()
+        return [r[0] for r in rows]

--- a/tests/test_champion_data.py
+++ b/tests/test_champion_data.py
@@ -60,3 +60,23 @@ async def test_leaderboard_and_rank(tmp_path):
     await data.close()
     db_path.unlink()
     assert not db_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_user(tmp_path):
+    db_path = tmp_path / "cleanup" / "points.db"
+    data = ChampionData(str(db_path))
+
+    await data.add_delta("user1", 5, "test")
+    await data.add_delta("user2", 3, "test")
+
+    await data.delete_user("user1")
+
+    leaderboard = await data.get_leaderboard(limit=10)
+    ids = [uid for uid, _ in leaderboard]
+    assert "user1" not in ids
+    assert await data.get_total("user1") == 0
+
+    await data.close()
+    db_path.unlink()
+    assert not db_path.exists()


### PR DESCRIPTION
## Summary
- fix leaderboard to use emoji mappings correctly
- add `/champion clean` command to purge entries of departed members
- extend `ChampionData` with deletion and enumeration helpers
- document new command
- test deletion logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418006dd9c832f9cafe2c37b335c8f