### PR TITLE
Ensure guild-only commands and add guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Developer Guidelines
+
+- Use **guild-based** slash commands only. Register command groups with `bot.tree.add_command(..., guild=bot.main_guild)` and sync via `await bot.tree.sync(guild=bot.main_guild)`.
+- Do not register global commands. Remove obsolete global commands with `self.tree.clear_commands()` if needed.
+- The bot is hosted on **Railway**. Environment variables like `bot_key` and `server_id` are provided there.
+- Unit tests run locally without these variables. Use `monkeypatch.setenv` to simulate them, as shown in `tests/conftest.py`.

--- a/bot.py
+++ b/bot.py
@@ -113,7 +113,10 @@ class MyBot(commands.Bot):
 
     async def setup_hook(self) -> None:
         """Set up data and register all cogs and slash commands."""
-        # Optional: Commands leeren für Guild (verhindert Ghost-Kommandos bei Updates)
+        # Entferne eventuelle globale Kommandos und sync sie leer
+        self.tree.clear_commands()
+        await self.tree.sync()
+        # Commands für die Guild leeren, um Ghost-Einträge zu vermeiden
         self.tree.clear_commands(guild=self.main_guild)
 
 


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with developer guidelines about guild commands and env vars
- purge global commands during setup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841882db21c832fa55fda86bf5af089