### PR TITLE
Ensure clear_commands uses guild None

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Developer Guidelines
 
 - Use **guild-based** slash commands only. Register command groups with `bot.tree.add_command(..., guild=bot.main_guild)` and sync via `await bot.tree.sync(guild=bot.main_guild)`.
-- Do not register global commands. Remove obsolete global commands with `self.tree.clear_commands()` if needed.
+- Do not register global commands. Remove obsolete global commands with
+  `self.tree.clear_commands(guild=None)` if needed.
 - The bot is hosted on **Railway**. Environment variables like `bot_key` and `server_id` are provided there.
 - Unit tests run locally without these variables. Use `monkeypatch.setenv` to simulate them, as shown in `tests/conftest.py`.

--- a/bot.py
+++ b/bot.py
@@ -114,7 +114,7 @@ class MyBot(commands.Bot):
     async def setup_hook(self) -> None:
         """Set up data and register all cogs and slash commands."""
         # Entferne eventuelle globale Kommandos und sync sie leer
-        self.tree.clear_commands()
+        self.tree.clear_commands(guild=None)
         await self.tree.sync()
         # Commands für die Guild leeren, um Ghost-Einträge zu vermeiden
         self.tree.clear_commands(guild=self.main_guild)

--- a/tests/test_bot_setup.py
+++ b/tests/test_bot_setup.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from bot import MyBot
+
+
+@pytest.mark.asyncio
+async def test_setup_hook_clears_global_commands(monkeypatch):
+    bot = MyBot()
+
+    clear_calls = []
+
+    def fake_clear(guild=None):
+        clear_calls.append(guild)
+
+    async def fake_sync(guild=None):
+        pass
+
+    monkeypatch.setattr(bot.tree, "clear_commands", fake_clear)
+    monkeypatch.setattr(bot.tree, "sync", fake_sync)
+
+    monkeypatch.setattr("bot.load_json", lambda path: {})
+    monkeypatch.setattr("bot.load_wcr_data", lambda: {})
+    monkeypatch.setattr("bot.load_quiz_config", lambda b: None)
+    async def nop(bot):
+        return None
+    monkeypatch.setattr("cogs.quiz.setup", nop)
+    monkeypatch.setattr("cogs.wcr.setup", nop)
+    monkeypatch.setattr("cogs.champion.setup", nop)
+    monkeypatch.setattr("bot.Path.glob", lambda self, pattern: [])
+    monkeypatch.setattr(bot, "_load_emojis_from_file", lambda: {})
+
+    await bot.setup_hook()
+
+    assert None in clear_calls


### PR DESCRIPTION
## Summary
- call `self.tree.clear_commands(guild=None)` before syncing
- note new call signature in developer guidelines
- test that setup uses this new call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418c25b2d4832f8e7f2ec0af3edf68