### PR TITLE
Remove test sys.path insert blocks

### DIFF
--- a/tests/champion/test_champion_cog.py
+++ b/tests/champion/test_champion_cog.py
@@ -3,7 +3,6 @@ import sys
 import asyncio
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.champion.cog import ChampionCog
 from cogs.champion.data import ChampionData

--- a/tests/champion/test_champion_data.py
+++ b/tests/champion/test_champion_data.py
@@ -2,8 +2,6 @@ import os
 import sys
 import pytest
 
-# Add the project root to sys.path so that `cogs` can be imported
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.champion.data import ChampionData
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,10 @@
+import os
+import sys
 import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
 
 @pytest.fixture(autouse=True)
 def _set_env(monkeypatch):

--- a/tests/general/test_bot_setup.py
+++ b/tests/general/test_bot_setup.py
@@ -2,7 +2,6 @@ import os
 import sys
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from bot import MyBot
 

--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -2,7 +2,6 @@ import os
 import sys
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from bot import MyBot
 from cogs import quiz, champion, wcr

--- a/tests/general/test_utils_functions.py
+++ b/tests/general/test_utils_functions.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.utils import create_permutations, create_permutations_list, normalize_text
 

--- a/tests/quiz/test_check_answer.py
+++ b/tests/quiz/test_check_answer.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-# Add the project root to sys.path so that `cogs` can be imported
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.utils import check_answer
 

--- a/tests/quiz/test_duel.py
+++ b/tests/quiz/test_duel.py
@@ -4,7 +4,6 @@ import datetime
 import discord
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.duel import QuizDuelGame, DuelInviteView, DuelConfig, DuelQuestionView
 

--- a/tests/quiz/test_duel_question_view.py
+++ b/tests/quiz/test_duel_question_view.py
@@ -3,7 +3,6 @@ import sys
 import datetime
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.duel import DuelQuestionView
 

--- a/tests/quiz/test_load_quiz_config.py
+++ b/tests/quiz/test_load_quiz_config.py
@@ -3,7 +3,6 @@ import sys
 import json
 import datetime
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from bot import load_quiz_config
 from cogs.quiz.question_state import QuestionStateManager

--- a/tests/quiz/test_message_tracker.py
+++ b/tests/quiz/test_message_tracker.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.message_tracker import MessageTracker
 from cogs.quiz.quiz_config import QuizAreaConfig

--- a/tests/quiz/test_question_generator.py
+++ b/tests/quiz/test_question_generator.py
@@ -2,7 +2,6 @@ import os
 import sys
 import random
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.question_generator import QuestionGenerator
 

--- a/tests/quiz/test_question_state_manager.py
+++ b/tests/quiz/test_question_state_manager.py
@@ -2,7 +2,6 @@ import os
 import sys
 import json
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.question_state import QuestionStateManager
 

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from bot import MyBot
 import cogs.quiz.cog as quiz_cog_mod

--- a/tests/quiz/test_quiz_setup.py
+++ b/tests/quiz/test_quiz_setup.py
@@ -2,7 +2,6 @@ import os
 import sys
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from bot import MyBot
 from cogs import quiz

--- a/tests/wcr/test_wcr_helpers.py
+++ b/tests/wcr/test_wcr_helpers.py
@@ -3,8 +3,6 @@ import sys
 import json
 import pytest
 
-# Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.wcr import helpers
 

--- a/tests/wcr/test_wcr_question_provider.py
+++ b/tests/wcr/test_wcr_question_provider.py
@@ -3,8 +3,6 @@ import sys
 import json
 import random
 
-# Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from cogs.quiz.area_providers.wcr import WCRQuestionProvider
 from cogs.quiz.area_providers.base import DynamicQuestionProvider


### PR DESCRIPTION
## Summary
- include project root in `tests/conftest.py`
- drop duplicate `sys.path.insert` blocks across tests
- clean up leftover comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c44d345c832fad944a9d03211314