### PR TITLE
Improve tests and CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203,W503,E501,E302,E303,E305,E306

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest pytest-asyncio
+          pip install flake8
+      - name: Run linter
+        run: |
+          flake8 .
       - name: Run tests
         run: |
           pytest -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,5 @@
   `self.tree.clear_commands(guild=None)` if needed.
 - The bot is hosted on **Railway**. Environment variables like `bot_key` and `server_id` are provided there.
 - Unit tests run locally without these variables. Use `monkeypatch.setenv` to simulate them, as shown in `tests/conftest.py`.
+- A fixture `patch_logged_task` is provided for tests to replace `create_logged_task` with a dummy. Use it instead of duplicating patch code.
+- The CI workflow runs `flake8` for linting. Ensure your code passes the linter before committing.

--- a/tests/champion/test_champion_data.py
+++ b/tests/champion/test_champion_data.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import pytest
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,28 @@ if ROOT not in sys.path:
 @pytest.fixture(autouse=True)
 def _set_env(monkeypatch):
     monkeypatch.setenv("server_id", "0")
+
+
+class DummyTask:
+    def __init__(self):
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+@pytest.fixture
+def patch_logged_task(monkeypatch):
+    """Patch create_logged_task in the given modules with a dummy implementation."""
+
+    def apply(*modules):
+        def fake_task(coro, logger=None):
+            coro.close()
+            return DummyTask()
+
+        for module in modules:
+            monkeypatch.setattr(module, "create_logged_task", fake_task)
+
+        return fake_task
+
+    return apply

--- a/tests/general/test_bot_setup.py
+++ b/tests/general/test_bot_setup.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import pytest
 
 

--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import pytest
 
 
@@ -14,12 +12,8 @@ from cogs.wcr.utils import load_wcr_data
 
 
 @pytest.mark.asyncio
-async def test_quiz_setup_uses_main_guild(monkeypatch):
-    def fake_task(coro, logger):
-        coro.close()
-
-    monkeypatch.setattr(quiz_cog_mod, "create_logged_task", fake_task)
-    monkeypatch.setattr(msg_mod, "create_logged_task", fake_task)
+async def test_quiz_setup_uses_main_guild(monkeypatch, patch_logged_task):
+    patch_logged_task(quiz_cog_mod, msg_mod)
 
     bot = MyBot()
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}

--- a/tests/general/test_utils_functions.py
+++ b/tests/general/test_utils_functions.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from cogs.quiz.utils import create_permutations, create_permutations_list, normalize_text

--- a/tests/quiz/test_check_answer.py
+++ b/tests/quiz/test_check_answer.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from cogs.quiz.utils import check_answer

--- a/tests/quiz/test_duel.py
+++ b/tests/quiz/test_duel.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import datetime
 import discord
 import pytest

--- a/tests/quiz/test_duel_question_view.py
+++ b/tests/quiz/test_duel_question_view.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import datetime
 import pytest
 

--- a/tests/quiz/test_load_quiz_config.py
+++ b/tests/quiz/test_load_quiz_config.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 import datetime
 

--- a/tests/quiz/test_message_tracker.py
+++ b/tests/quiz/test_message_tracker.py
@@ -1,14 +1,15 @@
-import os
-import sys
 
 
 from cogs.quiz.message_tracker import MessageTracker
+import cogs.quiz.message_tracker as msg_mod
+import pytest
 from cogs.quiz.quiz_config import QuizAreaConfig
 
 
 class DummyAuthor:
-    def __init__(self, is_bot=False):
+    def __init__(self, is_bot=False, uid=0):
         self.bot = is_bot
+        self.id = uid
 
 
 class DummyChannel:
@@ -17,9 +18,10 @@ class DummyChannel:
 
 
 class DummyMessage:
-    def __init__(self, cid, is_bot=False):
-        self.author = DummyAuthor(is_bot)
+    def __init__(self, cid, is_bot=False, embed_title=None, uid=0):
+        self.author = DummyAuthor(is_bot, uid)
         self.channel = DummyChannel(cid)
+        self.embeds = [type("Embed", (), {"title": embed_title})()] if embed_title else []
 
 
 class DummyManager:
@@ -42,18 +44,20 @@ class DummyBot:
         self.quiz_data = {"area1": QuizAreaConfig(channel_id=123, activity_threshold=3)}
 
 
-def test_register_message_increments_and_triggers(monkeypatch):
+def test_register_message_increments_and_triggers(monkeypatch, patch_logged_task):
     bot = DummyBot()
     tracker = MessageTracker(bot, bot.quiz_cog.manager.ask_question)
     bot.quiz_cog.awaiting_activity = {123: ("area1", "end")}
 
     triggered = []
 
-    def fake_task(coro, logger):
-        triggered.append(coro)
-        coro.close()
+    base_task = patch_logged_task(msg_mod)
 
-    monkeypatch.setattr("cogs.quiz.message_tracker.create_logged_task", fake_task)
+    def wrapper(coro, logger):
+        triggered.append(coro)
+        base_task(coro, logger)
+
+    monkeypatch.setattr(msg_mod, "create_logged_task", wrapper, raising=False)
 
     msg = DummyMessage(123)
     tracker.register_message(msg)
@@ -64,3 +68,85 @@ def test_register_message_increments_and_triggers(monkeypatch):
     tracker.register_message(msg)
     assert tracker.get(123) == 3
     assert len(triggered) == 1
+
+
+@pytest.mark.asyncio
+async def test_initialize_counts_history(monkeypatch):
+    quiz_embed_title = "Quiz f\u00fcr AREA1"
+
+    msgs = [
+        DummyMessage(123, uid=1),
+        DummyMessage(123, is_bot=True, uid=2),
+        DummyMessage(123, is_bot=True, embed_title=quiz_embed_title, uid=999),
+    ]
+
+    class DummyChannel:
+        def __init__(self, cid, messages):
+            self.id = cid
+            self._msgs = messages
+
+        def history(self, limit=20):
+            async def gen():
+                for m in self._msgs:
+                    yield m
+
+            return gen()
+
+    class DummyBot:
+        def __init__(self):
+            self.quiz_data = {"area1": QuizAreaConfig(channel_id=123, activity_threshold=3)}
+            self.user = type("User", (), {"id": 999})()
+
+        async def wait_until_ready(self):
+            pass
+
+        async def fetch_channel(self, cid):
+            return DummyChannel(cid, msgs)
+
+    monkeypatch.setattr(msg_mod.discord, "TextChannel", DummyChannel)
+
+    bot = DummyBot()
+    tracker = MessageTracker(bot, None)
+
+    await tracker.initialize()
+
+    assert tracker.get(123) == 1
+    assert tracker.is_initialized(123)
+
+
+@pytest.mark.asyncio
+async def test_initialize_uses_threshold_when_no_quiz(monkeypatch):
+    msgs: list[DummyMessage] = [DummyMessage(123, uid=1), DummyMessage(123, uid=2)]
+
+    class DummyChannel:
+        def __init__(self, cid, messages):
+            self.id = cid
+            self._msgs = messages
+
+        def history(self, limit=20):
+            async def gen():
+                for m in self._msgs:
+                    yield m
+
+            return gen()
+
+    class DummyBot:
+        def __init__(self):
+            self.quiz_data = {"area1": QuizAreaConfig(channel_id=123, activity_threshold=3)}
+            self.user = type("User", (), {"id": 999})()
+
+        async def wait_until_ready(self):
+            pass
+
+        async def fetch_channel(self, cid):
+            return DummyChannel(cid, msgs)
+
+    monkeypatch.setattr(msg_mod.discord, "TextChannel", DummyChannel)
+
+    bot = DummyBot()
+    tracker = MessageTracker(bot, None)
+
+    await tracker.initialize()
+
+    assert tracker.get(123) == 3
+    assert tracker.is_initialized(123)

--- a/tests/quiz/test_question_generator.py
+++ b/tests/quiz/test_question_generator.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import random
 
 

--- a/tests/quiz/test_question_state_manager.py
+++ b/tests/quiz/test_question_state_manager.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from bot import MyBot
@@ -34,9 +32,8 @@ class DummyState:
     pass
 
 
-def test_scheduler_start_and_stop(monkeypatch):
-    monkeypatch.setattr(quiz_cog_mod, "create_logged_task", fake_task_general)
-    monkeypatch.setattr(msg_mod, "create_logged_task", fake_task_general)
+def test_scheduler_start_and_stop(monkeypatch, patch_logged_task):
+    patch_logged_task(quiz_cog_mod, msg_mod)
     monkeypatch.setattr(scheduler_mod, "create_logged_task", fake_task_scheduler)
     monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", lambda self: None)
 

--- a/tests/quiz/test_quiz_setup.py
+++ b/tests/quiz/test_quiz_setup.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import pytest
 
 
@@ -11,12 +9,8 @@ import cogs.quiz.message_tracker as msg_mod
 
 
 @pytest.mark.asyncio
-async def test_quiz_setup_registers_cog_and_commands(monkeypatch):
-    def fake_task(coro, logger):
-        coro.close()
-
-    monkeypatch.setattr(quiz_cog_mod, "create_logged_task", fake_task)
-    monkeypatch.setattr(msg_mod, "create_logged_task", fake_task)
+async def test_quiz_setup_registers_cog_and_commands(monkeypatch, patch_logged_task):
+    patch_logged_task(quiz_cog_mod, msg_mod)
 
     bot = MyBot()
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}

--- a/tests/wcr/test_wcr_helpers.py
+++ b/tests/wcr/test_wcr_helpers.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 import pytest
 

--- a/tests/wcr/test_wcr_question_provider.py
+++ b/tests/wcr/test_wcr_question_provider.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 import random
 


### PR DESCRIPTION
## Summary
- simplify test imports
- add a reusable `patch_logged_task` fixture
- extend tests for `MessageTracker.initialize`
- run flake8 in CI and add configuration
- update developer guidelines

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ca77c8bc832f96d041f368452f42