### PR TITLE
Improve moderation permission handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Willkommen beim **Lotus Gaming Discord Bot**! Dieser modulare Bot bietet interak
 - [Setup](#setup)
 - [Projektstruktur](#projektstruktur)
 - [Slash-Commands](#slash-commands)
+- [Berechtigungen](#berechtigungen)
 - [Technische Konzepte](#technische-konzepte)
 - [Tests](#tests)
 - [Änderungsprotokoll](#änderungsprotokoll)
@@ -119,6 +120,33 @@ Fragequellen verfügbar (derzeit nur `wcr`).
 ```
 
 Autocomplete und Fuzzy-Matching sind integriert.
+
+## Berechtigungen
+
+Einige Slash-Befehle sind nur für Moderatoren mit dem Recht **Manage Server**
+(``manage_guild``) nutzbar. Sie werden dank ``default_permissions`` nur diesen
+Nutzern angezeigt. Alle anderen Befehle stehen jedem Mitglied offen.
+
+**Moderatorenbefehle:**
+
+```
+/champion give
+/champion remove
+/champion set
+/champion reset
+/champion history
+/champion clean
+
+/quiz ask
+/quiz answer
+/quiz status
+/quiz disable
+/quiz enable
+/quiz language
+/quiz time
+/quiz threshold
+/quiz reset
+```
 
 ---
 

--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -15,6 +15,7 @@ champion_group = app_commands.Group(
 
 @champion_group.command(name="give", description="Gibt einem User Punkte (nur Mods)")
 @moderator_only()
+@app_commands.default_permissions(manage_guild=True)
 @app_commands.describe(user="Der Nutzer, dem Punkte gegeben werden", punkte="Anzahl der Punkte", grund="Begründung")
 async def give(interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str):
     """Give a user points."""
@@ -30,6 +31,7 @@ async def give(interaction: discord.Interaction, user: discord.Member, punkte: i
 
 @champion_group.command(name="remove", description="Entfernt Punkte (nur Mods)")
 @moderator_only()
+@app_commands.default_permissions(manage_guild=True)
 @app_commands.describe(user="Der Nutzer, von dem Punkte abgezogen werden", punkte="Anzahl der Punkte", grund="Begründung")
 async def remove(interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str):
     """Remove points from a user."""
@@ -45,6 +47,7 @@ async def remove(interaction: discord.Interaction, user: discord.Member, punkte:
 
 @champion_group.command(name="set", description="Setzt die Punktzahl eines Users (nur Mods)")
 @moderator_only()
+@app_commands.default_permissions(manage_guild=True)
 @app_commands.describe(user="Der Nutzer, dessen Punktzahl gesetzt wird", punkte="Neue Gesamtpunktzahl", grund="Begründung")
 async def set_points(interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str):
     """Set a user's score to an explicit value."""
@@ -62,6 +65,7 @@ async def set_points(interaction: discord.Interaction, user: discord.Member, pun
 
 @champion_group.command(name="reset", description="Setzt die Punkte eines Nutzers auf 0 (nur Mods)")
 @moderator_only()
+@app_commands.default_permissions(manage_guild=True)
 @app_commands.describe(user="Der Nutzer, dessen Punkte zurückgesetzt werden")
 async def reset(interaction: discord.Interaction, user: discord.Member):
     """Reset a user's score to zero."""
@@ -118,6 +122,7 @@ async def myhistory(interaction: discord.Interaction):
 
 @champion_group.command(name="history", description="Zeigt die Punkte-Historie eines Spielers")
 @moderator_only()
+@app_commands.default_permissions(manage_guild=True)
 @app_commands.describe(user="Der Spieler, dessen Historie angezeigt wird")
 async def history(interaction: discord.Interaction, user: discord.Member):
     """Display another user's score history."""
@@ -247,6 +252,7 @@ async def rank(interaction: discord.Interaction, user: discord.Member | None = N
 
 @champion_group.command(name="clean", description="Entfernt Einträge ehemaliger Mitglieder (nur Mods)")
 @moderator_only()
+@app_commands.default_permissions(manage_guild=True)
 async def clean(interaction: discord.Interaction):
     """Remove users from the database who left the server."""
     logger.info(f"/champion clean requested by {interaction.user}")

--- a/permissions.py
+++ b/permissions.py
@@ -1,13 +1,21 @@
 from discord import app_commands, Interaction
+from discord.app_commands import MissingPermissions
 
 
 def moderator_only():
+    """Return a check ensuring ``manage_guild`` and sending a message on failure."""
+
+    base = app_commands.checks.has_permissions(manage_guild=True)
+    dummy = base(lambda i: None)
+    base_predicate = dummy.__discord_app_commands_checks__[0]
+
     async def predicate(interaction: Interaction) -> bool:
-        if interaction.user.guild_permissions.manage_guild:
-            return True
-        await interaction.response.send_message(
-            "❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True
-        )
-        return False
+        try:
+            return base_predicate(interaction)
+        except MissingPermissions:
+            await interaction.response.send_message(
+                "❌ Du hast keine Berechtigung für diesen Befehl.", ephemeral=True
+            )
+            return False
 
     return app_commands.check(predicate)

--- a/tests/champion/test_permissions.py
+++ b/tests/champion/test_permissions.py
@@ -1,0 +1,58 @@
+import pytest
+
+from cogs.champion.slash_commands import champion_group
+from permissions import moderator_only
+
+
+class DummyPerms:
+    def __init__(self, manage):
+        self.manage_guild = manage
+
+
+class DummyUser:
+    def __init__(self, manage):
+        self.guild_permissions = DummyPerms(manage)
+
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, msg, ephemeral=False):
+        self.messages.append((msg, ephemeral))
+
+
+class DummyInteraction:
+    def __init__(self, manage):
+        self.user = DummyUser(manage)
+        self.permissions = DummyPerms(manage)
+        self.response = DummyResponse()
+
+
+def get_predicate():
+    func = moderator_only()(lambda i: None)
+    return func.__discord_app_commands_checks__[0]
+
+
+@pytest.mark.asyncio
+async def test_moderator_only_allows_mods():
+    predicate = get_predicate()
+    inter = DummyInteraction(True)
+    assert await predicate(inter) is True
+    assert inter.response.messages == []
+
+
+@pytest.mark.asyncio
+async def test_moderator_only_blocks_non_mods():
+    predicate = get_predicate()
+    inter = DummyInteraction(False)
+    assert await predicate(inter) is False
+    assert inter.response.messages
+    assert "❌" in inter.response.messages[0][0]
+
+
+def test_mod_commands_have_default_permissions():
+    mod_names = {"give", "remove", "set", "reset", "history", "clean"}
+    cmds = {c.name: c for c in champion_group.commands}
+    for name in mod_names:
+        assert cmds[name].default_permissions.manage_guild is True


### PR DESCRIPTION
## Summary
- show mod-only commands only to users with `Manage Server`
- rebuild `moderator_only` check using Discord's permission check
- add permissions section to README
- test decorator and command permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cb334134832fa3aed53145d6e1b5