### PR TITLE
Improve quiz question typing and provider registry

### DIFF
--- a/cogs/quiz/area_providers/base.py
+++ b/cogs/quiz/area_providers/base.py
@@ -1,7 +1,7 @@
 # cogs/quiz/area_providers/base.py
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from log_setup import get_logger
 
@@ -9,19 +9,22 @@ logger = get_logger(__name__)
 
 
 class DynamicQuestionProvider(ABC):
+    """Base class for providers generating dynamic quiz questions."""
+
+    question_generators: List[str] = []
+
     @abstractmethod
     def generate(self) -> Optional[Dict]:
         """Generiert eine einzelne Frage."""
         pass
 
     def generate_all_types(self) -> list[Dict]:
-        """Return one question for every generic type if available."""
+        """Return one question for every registered type if available."""
         questions = []
-        for attr in dir(self):
-            if attr.startswith("generate_type_"):
-                func = getattr(self, attr)
-                if callable(func):
-                    q = func()
-                    if q:
-                        questions.append(q)
+        for name in self.question_generators:
+            func = getattr(self, name, None)
+            if callable(func):
+                q = func()
+                if q:
+                    questions.append(q)
         return questions

--- a/cogs/quiz/area_providers/wcr.py
+++ b/cogs/quiz/area_providers/wcr.py
@@ -9,6 +9,14 @@ logger = get_logger(__name__)
 
 
 class WCRQuestionProvider(DynamicQuestionProvider):
+    question_generators = [
+        "generate_type_1",
+        "generate_type_2",
+        "generate_type_3",
+        "generate_type_4",
+        "generate_type_5",
+    ]
+
     def __init__(self, bot, language="de"):
         units_data = bot.data["wcr"].get("units", [])
         # ``units.json`` may wrap the list of units in a top level key
@@ -31,16 +39,9 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         return int(digest, 16)
 
     def generate(self):
-        types = [
-            self.generate_type_1,
-            self.generate_type_2,
-            self.generate_type_3,
-            self.generate_type_4,
-            self.generate_type_5,
-        ]
-
         questions = []
-        for func in types:
+        for name in self.question_generators:
+            func = getattr(self, name)
             q = func()
             if q:
                 questions.append(q)
@@ -55,18 +56,7 @@ class WCRQuestionProvider(DynamicQuestionProvider):
 
     def generate_all_types(self) -> list[dict]:
         """Generate one question for every available type."""
-        questions = []
-        for func in [
-            self.generate_type_1,
-            self.generate_type_2,
-            self.generate_type_3,
-            self.generate_type_4,
-            self.generate_type_5,
-        ]:
-            q = func()
-            if q:
-                questions.append(q)
-        return questions
+        return super().generate_all_types()
 
     def generate_type_1(self):
         talents = []

--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -4,7 +4,7 @@ import discord
 
 from log_setup import get_logger, create_logged_task
 
-from .question_state import QuestionStateManager
+from .question_state import QuestionStateManager, QuestionInfo
 from .scheduler import QuizScheduler
 from .question_restorer import QuestionRestorer
 from .question_manager import QuestionManager
@@ -22,7 +22,7 @@ class QuizCog(commands.Cog):
         if not self.bot.quiz_data:
             logger.warning("[QuizCog] Keine Quiz-Konfiguration geladen.")
 
-        self.current_questions: dict[str, dict] = {}
+        self.current_questions: dict[str, QuestionInfo] = {}
         self.answered_users: dict[str, set[int]] = defaultdict(set)
         self.awaiting_activity: dict[int, tuple[str, float]] = {}
 

--- a/cogs/quiz/question_closer.py
+++ b/cogs/quiz/question_closer.py
@@ -2,6 +2,7 @@ import discord
 import asyncio
 
 from log_setup import get_logger
+from .question_state import QuestionInfo
 
 
 class QuestionCloser:
@@ -13,7 +14,7 @@ class QuestionCloser:
     async def close_question(
         self,
         area: str,
-        qinfo: dict,
+        qinfo: QuestionInfo,
         timed_out: bool = False,
         winner: discord.User | None = None,
         correct_answer: str | None = None,
@@ -24,7 +25,7 @@ class QuestionCloser:
         channel = self.bot.get_channel(cfg.channel_id)
 
         try:
-            msg = await channel.fetch_message(qinfo["message_id"])
+            msg = await channel.fetch_message(qinfo.message_id)
             embed = msg.embeds[0]
             embed.color = discord.Color.red()
 
@@ -36,8 +37,7 @@ class QuestionCloser:
                 footer = "✋ Frage durch Mod beendet."
 
             embed.set_footer(text=footer)
-            embed.add_field(name="Richtige Antwort", value=", ".join(
-                qinfo["answers"]), inline=False)
+            embed.add_field(name="Richtige Antwort", value=", ".join(qinfo.answers), inline=False)
             await msg.edit(embed=embed, view=None)
 
             logger.info(f"[Closer] Frage in '{area}' geschlossen: {footer}")

--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -6,6 +6,7 @@ import discord
 from log_setup import get_logger
 
 from .views import AnswerButtonView
+from .question_state import QuestionInfo
 
 
 
@@ -86,18 +87,14 @@ class QuestionManager:
         logger.debug(
             f"[QuestionManager] Nachricht ID {sent_msg.id} an Channel {channel.id} gesendet.")
 
-        qinfo = {
-            "message_id": sent_msg.id,
-            "end_time": end_time.isoformat(),
-            "answers": correct_answers,
-            "frage": frage_text,
-            "category": question.get("category", "–")
-        }
-        self.cog.current_questions[area] = {
-            "message_id": sent_msg.id,
-            "end_time": end_time,
-            "answers": correct_answers
-        }
+        qinfo = QuestionInfo(
+            message_id=sent_msg.id,
+            end_time=end_time,
+            answers=correct_answers,
+            frage=frage_text,
+            category=question.get("category", "–"),
+        )
+        self.cog.current_questions[area] = qinfo
         self.cog.answered_users[area].clear()
         self.cog.tracker.reset(channel.id)
         self.cog.awaiting_activity.pop(channel.id, None)

--- a/cogs/quiz/scheduler.py
+++ b/cogs/quiz/scheduler.py
@@ -58,5 +58,6 @@ class QuizScheduler:
 
             cid = self.bot.quiz_data[self.area].channel_id
             self.bot.quiz_cog.awaiting_activity.pop(cid, None)
-            if self.area in self.bot.quiz_cog.current_questions:
-                await self.close_question(self.area, timed_out=True)
+            qinfo = self.bot.quiz_cog.current_questions.get(self.area)
+            if qinfo:
+                await self.close_question(self.area, qinfo=qinfo, timed_out=True)

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -192,13 +192,12 @@ async def answer(interaction: discord.Interaction):
     try:
         channel = interaction.client.get_channel(
             quiz_cog.bot.quiz_data[area].channel_id)
-        msg = await channel.fetch_message(question_data["message_id"])
+        msg = await channel.fetch_message(question_data.message_id)
         embed = msg.embeds[0]
         embed.color = discord.Color.red()
 
-        answers = question_data["answers"]
-        answer_text = ", ".join(str(a) for a in answers) if isinstance(
-            answers, (list, set)) else str(answers)
+        answers = question_data.answers
+        answer_text = ", ".join(str(a) for a in answers)
         embed.add_field(name="Richtige Antwort",
                         value=answer_text, inline=False)
         embed.set_footer(text="✋ Frage durch Mod beendet.")
@@ -223,7 +222,7 @@ async def status(interaction: discord.Interaction):
     count = quiz_cog.tracker.get(interaction.channel.id)
     if question_data:
         remaining = int(
-            (question_data["end_time"] - datetime.datetime.utcnow()).total_seconds())
+            (question_data.end_time - datetime.datetime.utcnow()).total_seconds())
         await interaction.response.send_message(
             f"📊 Aktive Frage: noch **{remaining}s**. Nachrichten seit Start: **{count}**.", ephemeral=True
         )

--- a/tests/quiz/test_question_state_manager.py
+++ b/tests/quiz/test_question_state_manager.py
@@ -1,20 +1,27 @@
 import json
+import datetime
 
 
-from cogs.quiz.question_state import QuestionStateManager
+from cogs.quiz.question_state import QuestionStateManager, QuestionInfo
 
 
 def test_set_active_question(tmp_path):
     state_file = tmp_path / "state.json"
     manager = QuestionStateManager(str(state_file))
-    question = {"id": 1, "text": "foo"}
+    question = QuestionInfo(
+        message_id=1,
+        end_time=datetime.datetime.utcnow(),
+        answers=["a"],
+        frage="foo",
+    )
     manager.set_active_question("area1", question)
 
-    assert manager.get_active_question("area1") == question
+    restored = manager.get_active_question("area1")
+    assert restored == question
 
     with open(state_file, "r", encoding="utf-8") as f:
         saved = json.load(f)
-    assert saved["active"]["area1"] == question
+    assert saved["active"]["area1"] == question.to_dict()
 
 
 def test_mark_question_as_asked(tmp_path):


### PR DESCRIPTION
## Summary
- use `QuestionInfo` dataclass for active/persisted quiz questions
- keep question references typed across cog, manager, restorer and closer
- expose explicit list of question type generators
- adjust WCR provider to use registry
- update tests for new dataclass

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841cb559ffc832f9edc1d1ff816076e