### PR TITLE
Add reusable bot fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import pytest
+import pytest_asyncio
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:
@@ -34,3 +35,15 @@ def patch_logged_task(monkeypatch):
         return fake_task
 
     return apply
+
+
+@pytest_asyncio.fixture
+async def bot():
+    """Yield a ``MyBot`` instance and ensure it is properly closed."""
+    from bot import MyBot
+
+    bot = MyBot()
+    try:
+        yield bot
+    finally:
+        await bot.close()

--- a/tests/general/test_bot_setup.py
+++ b/tests/general/test_bot_setup.py
@@ -1,12 +1,8 @@
 import pytest
 
 
-from bot import MyBot
-
-
 @pytest.mark.asyncio
-async def test_setup_hook_clears_global_commands(monkeypatch):
-    bot = MyBot()
+async def test_setup_hook_clears_global_commands(monkeypatch, bot):
 
     clear_calls = []
 

--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from bot import MyBot
+
 from cogs import quiz, champion, wcr
 from cogs.quiz.slash_commands import quiz_group
 from cogs.champion.slash_commands import champion_group
@@ -12,10 +12,8 @@ from cogs.wcr.utils import load_wcr_data
 
 
 @pytest.mark.asyncio
-async def test_quiz_setup_uses_main_guild(monkeypatch, patch_logged_task):
+async def test_quiz_setup_uses_main_guild(monkeypatch, patch_logged_task, bot):
     patch_logged_task(quiz_cog_mod, msg_mod)
-
-    bot = MyBot()
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
     bot.quiz_data = {}
 
@@ -32,8 +30,7 @@ async def test_quiz_setup_uses_main_guild(monkeypatch, patch_logged_task):
 
 
 @pytest.mark.asyncio
-async def test_champion_setup_uses_main_guild(monkeypatch):
-    bot = MyBot()
+async def test_champion_setup_uses_main_guild(monkeypatch, bot):
     bot.data = {"champion": {"roles": []}, "emojis": {}}
 
     called = []
@@ -49,8 +46,7 @@ async def test_champion_setup_uses_main_guild(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_wcr_setup_uses_main_guild(monkeypatch):
-    bot = MyBot()
+async def test_wcr_setup_uses_main_guild(monkeypatch, bot):
     bot.data = {"wcr": load_wcr_data(), "emojis": {}}
 
     called = []

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -1,6 +1,6 @@
 
 
-from bot import MyBot
+
 import cogs.quiz.cog as quiz_cog_mod
 import cogs.quiz.scheduler as scheduler_mod
 import cogs.quiz.message_tracker as msg_mod
@@ -32,12 +32,15 @@ class DummyState:
     pass
 
 
-def test_scheduler_start_and_stop(monkeypatch, patch_logged_task):
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_scheduler_start_and_stop(monkeypatch, patch_logged_task, bot):
     patch_logged_task(quiz_cog_mod, msg_mod)
     monkeypatch.setattr(scheduler_mod, "create_logged_task", fake_task_scheduler)
     monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", lambda self: None)
 
-    bot = MyBot()
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
     bot.quiz_data = {
         "area1": {"channel_id": 1, "active": True, "question_state": DummyState()},

--- a/tests/quiz/test_quiz_setup.py
+++ b/tests/quiz/test_quiz_setup.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from bot import MyBot
+
 from cogs import quiz
 from cogs.quiz.slash_commands import quiz_group
 import cogs.quiz.cog as quiz_cog_mod
@@ -9,10 +9,8 @@ import cogs.quiz.message_tracker as msg_mod
 
 
 @pytest.mark.asyncio
-async def test_quiz_setup_registers_cog_and_commands(monkeypatch, patch_logged_task):
+async def test_quiz_setup_registers_cog_and_commands(monkeypatch, patch_logged_task, bot):
     patch_logged_task(quiz_cog_mod, msg_mod)
-
-    bot = MyBot()
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
     bot.quiz_data = {}
 


### PR DESCRIPTION
## Summary
- add `bot` fixture using `pytest_asyncio` to ensure bots are closed after tests
- use the new fixture in setup tests for general cogs and quiz
- convert scheduler test to async and clean up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fe0c3608832f963e2b02e50be44c