### PR TITLE
Add cog_unload hooks

### DIFF
--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 from typing import Optional
+import asyncio
 
 from log_setup import get_logger, create_logged_task
 from .data import ChampionData
@@ -108,3 +109,6 @@ class ChampionCog(commands.Cog):
             logger.warning(
                 f"[ChampionCog] Rolle '{target_role_name}' existiert nicht in Discord."
             )
+
+    def cog_unload(self):
+        asyncio.create_task(self.data.close())

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -581,3 +581,6 @@ class WCRCog(commands.Cog):
             logger.error(
                 f"Fehler beim Senden des Embeds für unit_id {unit_id}: {e}", exc_info=True)
             await interaction.followup.send("Ein Fehler ist aufgetreten.", ephemeral=True)
+
+    def cog_unload(self):
+        pass

--- a/tests/champion/test_champion_cog.py
+++ b/tests/champion/test_champion_cog.py
@@ -37,9 +37,12 @@ async def test_update_user_score_saves_and_calls(monkeypatch, patch_logged_task,
     await asyncio.sleep(0)
     assert total == 5
     assert called == [("123", 5)]
+    cog.cog_unload()
+    await asyncio.sleep(0)
 
 
-def test_get_current_role():
+@pytest.mark.asyncio
+async def test_get_current_role():
     bot = DummyBot()
     bot.data["champion"]["roles"] = [
         {"name": "Gold", "threshold": 50},
@@ -50,3 +53,5 @@ def test_get_current_role():
     assert cog.get_current_role(55) == "Gold"
     assert cog.get_current_role(25) == "Silver"
     assert cog.get_current_role(10) is None
+    cog.cog_unload()
+    await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- close ChampionData DB on ChampionCog unload
- add empty cog_unload to WCRCog
- clean up ChampionCog tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fe0a2088832f9c1ea997a600a5b2