### PR TITLE
Fix flake8 E402 in scheduler test

### DIFF
--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -4,6 +4,7 @@
 import cogs.quiz.cog as quiz_cog_mod
 import cogs.quiz.scheduler as scheduler_mod
 import cogs.quiz.message_tracker as msg_mod
+import pytest
 
 
 class DummyTask:
@@ -30,9 +31,6 @@ fake_task_scheduler.tasks = []
 
 class DummyState:
     pass
-
-
-import pytest
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move `pytest` import to top of `test_quiz_scheduler`

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684209fddde8832fb2e7998cb0c59427