### PR TITLE
Add category lookup dictionaries for WCR helpers

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -26,6 +26,8 @@ class WCRCog(commands.Cog):
         self.languages = bot.data["wcr"]["locals"]
         self.pictures = bot.data["wcr"]["pictures"]
 
+        helpers.build_category_lookup(self.languages, self.pictures)
+
         # Emojis liegen in bot.data["emojis"]
         self.emojis = bot.data["emojis"]
 

--- a/cogs/wcr/helpers.py
+++ b/cogs/wcr/helpers.py
@@ -6,6 +6,22 @@ from log_setup import get_logger
 logger = get_logger(__name__)
 
 
+def build_category_lookup(languages: dict, pictures: dict) -> None:
+    """Add lookup dictionaries for faster category access."""
+    for lang_data in languages.values():
+        categories = lang_data.get("categories", {})
+        lookup = {}
+        for name, items in categories.items():
+            lookup[name] = {item["id"]: item for item in items}
+        lang_data["category_lookup"] = lookup
+
+    pic_categories = pictures.get("categories", {})
+    pictures["category_lookup"] = {
+        name: {item["id"]: item for item in items}
+        for name, items in pic_categories.items()
+    }
+
+
 def get_text_data(unit_id: int, lang: str, languages: dict) -> tuple[str, str, list]:
     """Return name, description and talents for a unit in ``lang``."""
     texts = languages.get(lang, languages.get("de", {}))
@@ -23,25 +39,35 @@ def get_pose_url(unit_id: int, pictures: dict) -> str:
     """Return the pose image URL for a unit."""
     unit_pictures = pictures.get("units", [])
     unit_picture = next(
-        (pic for pic in unit_pictures if pic["id"] == unit_id), {})
+        (pic for pic in unit_pictures if pic["id"] == unit_id), {}
+    )
     return unit_picture.get("pose", "")
 
 
 def get_faction_data(faction_id: int, pictures: dict) -> dict:
     """Return faction meta information for ``faction_id``."""
-    factions = pictures.get("categories", {}).get("factions", [])
-    faction_data = next(
-        (faction for faction in factions if faction["id"] == faction_id), {})
-    return faction_data
+    factions = pictures.get("category_lookup", {}).get("factions")
+    if factions is None:
+        factions = {
+            f["id"]: f
+            for f in pictures.get("categories", {}).get("factions", [])
+        }
+    return factions.get(faction_id, {})
 
 
 def get_category_name(category: str, category_id: int, lang: str, languages: dict) -> str:
     """Return the localized name of a category item."""
-    categories = languages.get(
-        lang, {}).get("categories", {}).get(category, [])
-    category_item = next(
-        (item for item in categories if item["id"] == category_id), {})
-    return category_item.get("name", "Unbekannt")
+    cat_lookup = languages.get(lang, {}).get("category_lookup")
+    if cat_lookup is None:
+        categories = languages.get(lang, {}).get("categories", {})
+        cat_lookup = {
+            k: {item["id"]: item for item in v}
+            for k, v in categories.items()
+        }
+    item = cat_lookup.get(category, {}).get(category_id)
+    if item:
+        return item.get("name", "Unbekannt")
+    return "Unbekannt"
 
 
 def get_faction_icon(faction_id: int, pictures: dict) -> str:
@@ -58,9 +84,15 @@ def normalize_name(name: str) -> list[str]:
 def find_category_id(category_name: str, category: str, lang: str, languages: dict) -> int | None:
     """Return the ID of ``category_name`` searching all languages."""
     # Zuerst in der aktuellen Sprache suchen
-    category_list = languages[lang]['categories'][category]
+    lookup = languages[lang].get("category_lookup")
+    if lookup is None:
+        lookup = {
+            k: {i["id"]: i for i in v}
+            for k, v in languages[lang].get("categories", {}).items()
+        }
+    category_dict = lookup.get(category, {})
     matching_item = next(
-        (item for item in category_list if item['name'].lower() == category_name.lower()), None)
+        (item for item in category_dict.values() if item['name'].lower() == category_name.lower()), None)
     if matching_item:
         return matching_item['id']
 
@@ -68,9 +100,15 @@ def find_category_id(category_name: str, category: str, lang: str, languages: di
     for other_lang, other_texts in languages.items():
         if other_lang == lang:
             continue
-        category_list = other_texts['categories'][category]
+        lookup = other_texts.get("category_lookup")
+        if lookup is None:
+            lookup = {
+                k: {i["id"]: i for i in v}
+                for k, v in other_texts.get("categories", {}).items()
+            }
+        category_dict = lookup.get(category, {})
         matching_item = next(
-            (item for item in category_list if item['name'].lower() == category_name.lower()), None)
+            (item for item in category_dict.values() if item['name'].lower() == category_name.lower()), None)
         if matching_item:
             return matching_item['id']
 


### PR DESCRIPTION
## Summary
- speed up lookups for WCR categories by building `{id: data}` dictionaries
- refactor helper functions to use the new dictionaries
- initialize lookups in `WCRCog`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422616c520832f85c979ae62192641