### PR TITLE
Adjust history fetch limit in tracker

### DIFF
--- a/cogs/quiz/message_tracker.py
+++ b/cogs/quiz/message_tracker.py
@@ -31,7 +31,12 @@ class MessageTracker:
                         f"[Tracker] Channel {channel_id} ist kein TextChannel.")
                     continue
 
-                messages = [msg async for msg in channel.history(limit=20)]
+                messages = [
+                    msg
+                    async for msg in channel.history(
+                        limit=max(20, cfg.activity_threshold)
+                    )
+                ]
                 quiz_index = next((i for i, msg in enumerate(messages)
                                    if msg.author.id == self.bot.user.id and msg.embeds and
                                    msg.embeds[0].title.startswith(f"Quiz für {area.upper()}")), None)


### PR DESCRIPTION
## Summary
- fetch more channel history on initialization depending on activity threshold
- test new limit selection logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684226b8a998832f95846346c655c799