### PR TITLE
Add area-based scheduler management to quiz

### DIFF
--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -27,7 +27,8 @@ class QuizCog(commands.Cog):
         self.awaiting_activity: dict[int, tuple[str, float]] = {}
 
         # Keep track of schedulers to properly clean them up on unload
-        self.schedulers: list[QuizScheduler] = []
+        # Mapping area -> QuizScheduler
+        self.schedulers: dict[str, QuizScheduler] = {}
 
         # ``quiz_data`` might be empty if no areas are configured. In that case
         # fall back to a fresh ``QuestionStateManager`` so the cog can start
@@ -63,7 +64,7 @@ class QuizCog(commands.Cog):
                     prepare_question_callback=self.manager.prepare_question,
                     close_question_callback=self.closer.close_question,
                 )
-                self.schedulers.append(scheduler)
+                self.schedulers[area] = scheduler
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -73,5 +74,5 @@ class QuizCog(commands.Cog):
 
     def cog_unload(self):
         """Cancel all running scheduler tasks when the cog is unloaded."""
-        for scheduler in self.schedulers:
+        for scheduler in self.schedulers.values():
             scheduler.task.cancel()

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -1,6 +1,8 @@
 import cogs.quiz.cog as quiz_cog_mod
 import cogs.quiz.scheduler as scheduler_mod
 import cogs.quiz.message_tracker as msg_mod
+import cogs.quiz.slash_commands as slash_mod
+from cogs.quiz.quiz_config import QuizAreaConfig
 import pytest
 
 class DummyBot:
@@ -45,16 +47,67 @@ async def test_scheduler_start_and_stop(monkeypatch, patch_logged_task, bot):
 
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
     bot.quiz_data = {
-        "area1": {"channel_id": 1, "active": True, "question_state": DummyState()},
-        "area2": {"channel_id": 2, "active": False, "question_state": DummyState()},
+        "area1": QuizAreaConfig(channel_id=1, active=True, question_state=DummyState()),
+        "area2": QuizAreaConfig(channel_id=2, active=False, question_state=DummyState()),
     }
 
     cog = quiz_cog_mod.QuizCog(bot)
+    monkeypatch.setattr(bot, "get_cog", lambda name: cog if name == "QuizCog" else None)
 
-    assert len(cog.schedulers) == 1
+    assert list(cog.schedulers.keys()) == ["area1"]
     assert len(fake_task_scheduler.tasks) == 1
     task = fake_task_scheduler.tasks[0]
     assert not task.cancelled
 
     cog.cog_unload()
+    assert task.cancelled
+
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, content, **kwargs):
+        self.messages.append(content)
+
+
+class DummyChannel:
+    def __init__(self, cid):
+        self.id = cid
+
+
+class DummyInteraction:
+    def __init__(self, bot, channel):
+        self.client = bot
+        self.channel = channel
+        self.response = DummyResponse()
+
+
+@pytest.mark.asyncio
+async def test_enable_starts_and_disable_stops(monkeypatch, patch_logged_task, bot):
+    patch_logged_task(quiz_cog_mod, msg_mod)
+    monkeypatch.setattr(scheduler_mod, "create_logged_task", fake_task_scheduler)
+    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", lambda self: None)
+    monkeypatch.setattr(slash_mod, "save_area_config", lambda b: None)
+
+    bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
+    bot.quiz_data = {
+        "area1": QuizAreaConfig(channel_id=1, active=False, question_state=DummyState()),
+    }
+
+    cog = quiz_cog_mod.QuizCog(bot)
+    monkeypatch.setattr(bot, "get_cog", lambda name: cog if name == "QuizCog" else None)
+
+    assert not cog.schedulers
+
+    inter = DummyInteraction(bot, DummyChannel(1))
+    await slash_mod.enable.callback(inter, "area1")
+
+    assert "area1" in cog.schedulers
+    task = fake_task_scheduler.tasks[-1]
+    assert not task.cancelled
+
+    await slash_mod.disable.callback(inter)
+
+    assert "area1" not in cog.schedulers
     assert task.cancelled


### PR DESCRIPTION
## Summary
- map quiz schedulers by area in `QuizCog`
- start/stop schedulers in quiz `enable` and `disable` commands
- test scheduler start/stop on cog setup and via enable/disable

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684226c83f70832fa8aabf8d53158abc