### PR TITLE
Fix champion cog shutdown and tests

### DIFF
--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands
 from typing import Optional
-import asyncio
 
 from log_setup import get_logger, create_logged_task
 from .data import ChampionData
@@ -110,4 +109,4 @@ class ChampionCog(commands.Cog):
             )
 
     def cog_unload(self):
-        asyncio.create_task(self.data.close())
+        create_logged_task(self.data.close(), logger)


### PR DESCRIPTION
## Summary
- close ChampionData via `create_logged_task`
- avoid leftover asyncio tasks in champion cog tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422724a120832f8d4a8266eef249b6