### PR TITLE
Add role sync command

### DIFF
--- a/cogs/champion/__init__.py
+++ b/cogs/champion/__init__.py
@@ -10,13 +10,17 @@ logger = get_logger(__name__)
 async def setup(bot: discord.ext.commands.Bot):
     """Register cog and slash command group for the champion system."""
     try:
-        from .slash_commands import champion_group
+        from .slash_commands import champion_group, syncroles
         # 1) Haupt-Cog: Champion-Daten und Rolle-Logik
         await bot.add_cog(ChampionCog(bot))
 
         # 2) Slash-Gruppe /champion in den Command-Tree einfügen
         bot.tree.add_command(
             champion_group,
+            guild=bot.main_guild
+        )
+        bot.tree.add_command(
+            syncroles,
             guild=bot.main_guild
         )
 

--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -277,3 +277,21 @@ async def clean(interaction: discord.Interaction):
                 )
 
     await interaction.followup.send(f"🧹 Entfernte {removed} Einträge aus der Datenbank.")
+
+@app_commands.command(name="syncroles", description="Synchronisiert Champion-Rollen für alle gespeicherten Nutzer (nur Mods)")
+@moderator_only()
+@app_commands.default_permissions(manage_guild=True)
+async def syncroles(interaction: discord.Interaction):
+    """Sync champion roles for all users stored in the database."""
+    logger.info(f"/syncroles requested by {interaction.user}")
+    await interaction.response.defer(thinking=True)
+
+    cog: ChampionCog = interaction.client.get_cog("ChampionCog")
+    user_ids = await cog.data.get_all_user_ids()
+    processed = 0
+    for user_id_str in user_ids:
+        total = await cog.data.get_total(user_id_str)
+        await cog._apply_champion_role(user_id_str, total)
+        processed += 1
+
+    await interaction.followup.send(f"🔄 Synchronisierte Rollen für {processed} Nutzer.")

--- a/tests/champion/test_syncroles.py
+++ b/tests/champion/test_syncroles.py
@@ -1,0 +1,66 @@
+import pytest
+
+from cogs.champion.cog import ChampionCog
+from cogs.champion.data import ChampionData
+from cogs.champion.slash_commands import syncroles
+
+
+class DummyBot:
+    def __init__(self):
+        self.data = {"champion": {"roles": []}}
+        self.main_guild = None
+        self.guilds = []
+        self._cog = None
+
+    def get_cog(self, name):
+        return self._cog if name == "ChampionCog" else None
+
+
+class DummyResponse:
+    def __init__(self):
+        self.deferred = False
+
+    async def defer(self, thinking=False):
+        self.deferred = thinking
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, message):
+        self.sent.append(message)
+
+
+class DummyInteraction:
+    def __init__(self, bot):
+        self.user = "tester"
+        self.client = bot
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+        self.guild = None
+
+
+@pytest.mark.asyncio
+async def test_syncroles_processes_all_users(monkeypatch, tmp_path):
+    bot = DummyBot()
+    cog = ChampionCog(bot)
+    bot._cog = cog
+    cog.data = ChampionData(str(tmp_path / "points.db"))
+
+    await cog.data.add_delta("1", 5, "init")
+    await cog.data.add_delta("2", 3, "init")
+
+    called = []
+
+    async def fake_apply(uid, score):
+        called.append((uid, score))
+
+    monkeypatch.setattr(cog, "_apply_champion_role", fake_apply)
+
+    inter = DummyInteraction(bot)
+
+    await syncroles.callback(inter)
+
+    assert set(called) == {("1", 5), ("2", 3)}
+    assert inter.followup.sent

--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -4,7 +4,7 @@ import pytest
 
 from cogs import quiz, champion, wcr
 from cogs.quiz.slash_commands import quiz_group
-from cogs.champion.slash_commands import champion_group
+from cogs.champion.slash_commands import champion_group, syncroles
 from cogs.wcr.slash_commands import wcr_group
 import cogs.quiz.cog as quiz_cog_mod
 import cogs.quiz.message_tracker as msg_mod
@@ -42,7 +42,10 @@ async def test_champion_setup_uses_main_guild(monkeypatch, bot):
 
     await champion.setup(bot)
 
-    assert called == [(champion_group, bot.main_guild)]
+    assert called == [
+        (champion_group, bot.main_guild),
+        (syncroles, bot.main_guild),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `/syncroles` command for moderators to sync champion roles
- register this command
- test that `/syncroles` runs on stored users and update setup test expectations

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684227406f14832f96ac78b1fd7188c0