### PR TITLE
Update language policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,9 @@
 # Developer Guidelines
 
 - Use **guild-based** slash commands only. Register command groups with `bot.tree.add_command(..., guild=bot.main_guild)` and sync via `await bot.tree.sync(guild=bot.main_guild)`.
+- The bot operates on a **German-only** Discord server. All user-facing strings
+  and documentation should default to **German**. Support for other languages is
+  optional and requires explicit maintainer approval.
 - Do not register global commands. Remove obsolete global commands with
   `self.tree.clear_commands(guild=None)` if needed.
 - The bot is hosted on **Railway**. Environment variables like `bot_key` and `server_id` are provided there.


### PR DESCRIPTION
## Summary
- clarify that the Discord bot is for a German-only server
- specify default language for user strings and documentation
- note that other languages require maintainer approval

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684235aebf18832f80f88c51ae125184