### PR TITLE
Fix task cleanup and unload cogs in tests

### DIFF
--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 import discord
 
 from log_setup import get_logger, create_logged_task
+import asyncio
 
 from .question_state import QuestionStateManager, QuestionInfo
 from .scheduler import QuizScheduler
@@ -18,6 +19,16 @@ class QuizCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.bot.quiz_cog = self
+
+        # Track created background tasks to cancel them on unload
+        self.tasks: list[asyncio.Task] = []
+
+        def _track_task(coro, logger=logger):
+            task = create_logged_task(coro, logger)
+            self.tasks.append(task)
+            return task
+
+        self._track_task = _track_task
 
         if not self.bot.quiz_data:
             logger.warning("[QuizCog] Keine Quiz-Konfiguration geladen.")
@@ -49,10 +60,11 @@ class QuizCog(commands.Cog):
         self.tracker = MessageTracker(bot=self.bot, on_threshold=self.manager.ask_question)
         self.closer = QuestionCloser(bot=self.bot, state=self.state)
 
-        create_logged_task(self.tracker.initialize(), logger)
+        self.tasks.append(create_logged_task(self.tracker.initialize(), logger))
 
         self.restorer = QuestionRestorer(
-            bot=self.bot, state_manager=self.state)
+            bot=self.bot, state_manager=self.state, create_task=self._track_task
+        )
         self.restorer.restore_all()
 
         for area, cfg in self.bot.quiz_data.items():
@@ -65,6 +77,7 @@ class QuizCog(commands.Cog):
                     close_question_callback=self.closer.close_question,
                 )
                 self.schedulers[area] = scheduler
+                self.tasks.append(scheduler.task)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -73,6 +86,8 @@ class QuizCog(commands.Cog):
         self.tracker.register_message(message)
 
     def cog_unload(self):
-        """Cancel all running scheduler tasks when the cog is unloaded."""
+        """Cancel all running background tasks when the cog is unloaded."""
         for scheduler in self.schedulers.values():
             scheduler.task.cancel()
+        for task in self.tasks:
+            task.cancel()

--- a/cogs/quiz/question_restorer.py
+++ b/cogs/quiz/question_restorer.py
@@ -10,10 +10,11 @@ logger = get_logger(__name__)
 
 
 class QuestionRestorer:
-    def __init__(self, bot, state_manager) -> None:
+    def __init__(self, bot, state_manager, create_task=create_logged_task) -> None:
         """Restore running questions after a bot restart."""
         self.bot = bot
         self.state = state_manager
+        self.create_task = create_task
 
     def restore_all(self) -> None:
         """Recreate all still active questions from persisted state."""
@@ -27,7 +28,7 @@ class QuestionRestorer:
                     logger.info(
                         f"[Restorer] Wiederhergestellte Frage in '{area}' läuft bis {end_time}."
                     )
-                    create_logged_task(
+                    self.create_task(
                         self.repost_question(area, active), logger)
                 else:
                     self.state.clear_active_question(area)
@@ -92,7 +93,7 @@ class QuestionRestorer:
 
             delay = max(
                 (end_time - datetime.datetime.utcnow()).total_seconds(), 0)
-            create_logged_task(
+            self.create_task(
                 self.bot.quiz_cog.closer.auto_close(area, delay), logger
             )
 

--- a/tests/champion/test_champion_cog.py
+++ b/tests/champion/test_champion_cog.py
@@ -131,6 +131,7 @@ async def test_apply_role_removes_when_below_threshold(monkeypatch, patch_logged
 
     assert member.removed == [silver]
     assert member.added == []
+    await cog.data.close()
 
 
 @pytest.mark.asyncio
@@ -153,3 +154,4 @@ async def test_apply_role_prefers_get_member(monkeypatch):
 
     assert guild.get_calls == 1
     assert guild.fetch_calls == 0
+    await cog.data.close()

--- a/tests/champion/test_syncroles.py
+++ b/tests/champion/test_syncroles.py
@@ -64,3 +64,4 @@ async def test_syncroles_processes_all_users(monkeypatch, tmp_path):
 
     assert set(called) == {("1", 5), ("2", 3)}
     assert inter.followup.sent
+    await cog.data.close()

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -61,6 +61,7 @@ async def test_cmd_filter_no_emojis():
     msg = inter.response.messages[0]
     assert isinstance(msg["view"], MiniSelectView)
     assert msg["ephemeral"] is True
+    cog.cog_unload()
 
 
 @pytest.mark.asyncio
@@ -87,6 +88,7 @@ async def test_cmd_filter_generates_options():
     expected = [names[u["id"]] for u in units if u["cost"] == 6]
 
     assert [o.label for o in options] == expected
+    cog.cog_unload()
 
 
 @pytest.mark.asyncio
@@ -107,6 +109,7 @@ async def test_cmd_name_creates_embed():
     assert embed.thumbnail.url.endswith("Statue_Abomination_Pose.webp")
     assert embed.fields[0].name.strip() == "Cost"
     assert embed.fields[0].value == "6"
+    cog.cog_unload()
 
 
 def test_name_map_contains_unit():
@@ -139,6 +142,7 @@ async def test_select_view_timeout_disables_select():
     await view.on_timeout()
 
     assert select.disabled is True
+    cog.cog_unload()
 
 
 def test_init_without_en_language(caplog):
@@ -150,6 +154,7 @@ def test_init_without_en_language(caplog):
 
     assert cog.speed_choices
     assert any("language not found" in r.message for r in caplog.records)
+    cog.cog_unload()
 
 
 @pytest.mark.asyncio
@@ -163,6 +168,7 @@ async def test_cost_autocomplete_returns_all():
     expected = [str(c) for c in sorted({1, 2, 3, 4, 5, 6})]
     assert [c.name for c in choices] == expected
     assert [c.value for c in choices] == expected
+    cog.cog_unload()
 
 
 @pytest.mark.asyncio
@@ -175,6 +181,7 @@ async def test_speed_autocomplete_matches_substring():
 
     assert [c.name for c in choices] == ["Med-Fast", "Fast"]
     assert [c.value for c in choices] == ["2", "4"]
+    cog.cog_unload()
 
 
 @pytest.mark.asyncio
@@ -188,6 +195,7 @@ async def test_faction_autocomplete_case_insensitive():
     assert len(choices) == 1
     assert choices[0].name == "Undead"
     assert choices[0].value == "1"
+    cog.cog_unload()
 
 
 @pytest.mark.asyncio
@@ -200,6 +208,7 @@ async def test_type_autocomplete_multiple_results():
 
     assert [c.name for c in choices] == ["Spell", "Leader"]
     assert [c.value for c in choices] == ["2", "3"]
+    cog.cog_unload()
 
 
 @pytest.mark.asyncio
@@ -212,3 +221,4 @@ async def test_trait_autocomplete_returns_sorted_matches():
 
     assert [c.name for c in choices] == ["Melee", "Elemental"]
     assert [c.value for c in choices] == ["3", "8"]
+    cog.cog_unload()


### PR DESCRIPTION
## Summary
- ensure `QuizCog` tracks all background tasks and cancels them on unload
- allow `QuestionRestorer` to use a custom task creator
- call `cog_unload()` or close data in tests to avoid leftover tasks

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842395a90e0832fbee4492c1b1f3ad6