### PR TITLE
Refactor QuizCog initialization

### DIFF
--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -1,29 +1,33 @@
-from collections import defaultdict
-from discord.ext import commands
-import discord
+from __future__ import annotations
 
-from log_setup import get_logger, create_logged_task
 import asyncio
+from collections import defaultdict
 
-from .question_state import QuestionStateManager, QuestionInfo
-from .scheduler import QuizScheduler
-from .question_restorer import QuestionRestorer
-from .question_manager import QuestionManager
+import discord
+from discord.ext import commands
+
+from log_setup import create_logged_task, get_logger
+
 from .message_tracker import MessageTracker
 from .question_closer import QuestionCloser
+from .question_manager import QuestionManager
+from .question_restorer import QuestionRestorer
+from .question_state import QuestionInfo, QuestionStateManager
+from .scheduler import QuizScheduler
 
 logger = get_logger(__name__)
 
 
 class QuizCog(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        # Allow other modules to access the cog instance
         self.bot.quiz_cog = self
 
-        # Track created background tasks to cancel them on unload
+        # list of asyncio.Task objects created via ``_track_task``
         self.tasks: list[asyncio.Task] = []
 
-        def _track_task(coro, logger=logger):
+        def _track_task(coro: asyncio.coroutine) -> asyncio.Task:
             task = create_logged_task(coro, logger)
             self.tasks.append(task)
             return task
@@ -36,36 +40,26 @@ class QuizCog(commands.Cog):
         self.current_questions: dict[str, QuestionInfo] = {}
         self.answered_users: dict[str, set[int]] = defaultdict(set)
         self.awaiting_activity: dict[int, tuple[str, float]] = {}
-
-        # Keep track of schedulers to properly clean them up on unload
-        # Mapping area -> QuizScheduler
         self.schedulers: dict[str, QuizScheduler] = {}
 
-        # ``quiz_data`` might be empty if no areas are configured. In that case
-        # fall back to a fresh ``QuestionStateManager`` so the cog can start
-        # without raising an exception during initialization.
-        self.state: QuestionStateManager = next(
-            (
-                (
-                    cfg.question_state
-                    if hasattr(cfg, "question_state")
-                    else cfg.get("question_state")
-                )
-                for cfg in self.bot.quiz_data.values()
-                if hasattr(cfg, "question_state")
-                or (isinstance(cfg, dict) and "question_state" in cfg)
-            ),
-            QuestionStateManager("data/pers/quiz/question_state.json"),
-        )
+        # Find existing QuestionStateManager or create a default one
+        state = None
+        for cfg in self.bot.quiz_data.values():
+            if hasattr(cfg, "question_state"):
+                state = cfg.question_state
+                break
+            if isinstance(cfg, dict) and "question_state" in cfg:
+                state = cfg["question_state"]
+                break
+        if state is None:
+            state = QuestionStateManager("data/pers/quiz/question_state.json")
+        self.state: QuestionStateManager = state
 
         self.manager = QuestionManager(self)
-        self.tracker = MessageTracker(
-            bot=self.bot, on_threshold=self.manager.ask_question
-        )
+        self.tracker = MessageTracker(self.bot, self.manager.ask_question)
         self.closer = QuestionCloser(bot=self.bot, state=self.state)
 
-        self.init_task = create_logged_task(self.tracker.initialize(), logger)
-        self.tasks.append(create_logged_task(self.tracker.initialize(), logger))
+        self._track_task(self.tracker.initialize())
 
         self.restorer = QuestionRestorer(
             bot=self.bot, state_manager=self.state, create_task=self._track_task
@@ -74,39 +68,33 @@ class QuizCog(commands.Cog):
 
         for area, cfg in self.bot.quiz_data.items():
             active = cfg.active if hasattr(cfg, "active") else cfg.get("active")
-            if active:
-                sched_info = self.state.get_schedule(area)
-                if sched_info:
-                    post_time, window_end = sched_info
-                else:
-                    post_time = window_end = None
-                scheduler = QuizScheduler(
-                    bot=self.bot,
-                    area=area,
-                    prepare_question_callback=self.manager.prepare_question,
-                    close_question_callback=self.closer.close_question,
-                    post_time=post_time,
-                    window_end=window_end,
-                )
-                self.schedulers[area] = scheduler
-                self.tasks.append(scheduler.task)
+            if not active:
+                continue
+            sched_info = self.state.get_schedule(area)
+            if sched_info:
+                post_time, window_end = sched_info
+            else:
+                post_time = window_end = None
+            scheduler = QuizScheduler(
+                bot=self.bot,
+                area=area,
+                prepare_question_callback=self.manager.prepare_question,
+                close_question_callback=self.closer.close_question,
+                post_time=post_time,
+                window_end=window_end,
+            )
+            self.schedulers[area] = scheduler
 
     @commands.Cog.listener()
-    async def on_message(self, message: discord.Message):
+    async def on_message(self, message: discord.Message) -> None:
         if message.author.bot:
             return
         self.tracker.register_message(message)
 
-    def cog_unload(self):
-        """Cancel all running tasks when the cog is unloaded."""
+    def cog_unload(self) -> None:
         for scheduler in self.schedulers.values():
             scheduler.task.cancel()
-        if hasattr(self, "init_task"):
-            self.init_task.cancel()
         if hasattr(self.restorer, "cancel_all"):
             self.restorer.cancel_all()
-        """Cancel all running background tasks when the cog is unloaded."""
-        for scheduler in self.schedulers.values():
-            scheduler.task.cancel()
         for task in self.tasks:
             task.cancel()


### PR DESCRIPTION
## Summary
- refactor `QuizCog` to initialise managers and schedulers cleanly
- track background tasks via `_track_task`
- unify cleanup of tasks and schedulers

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684283d4dca4832fa319c54c8886d6c7