### PR TITLE
Adjust PTCGP database path

### DIFF
--- a/cogs/ptcgp/cog.py
+++ b/cogs/ptcgp/cog.py
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 class PTCGPCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self.data = PTCGPData("data/ptcgp/cards.db")
+        self.data = PTCGPData("data/pers/ptcgp/cards.db")
         self._lock = asyncio.Lock()
 
     async def update_database(self) -> dict[str, int]:


### PR DESCRIPTION
## Summary
- store PTCGP cards.db under `data/pers/ptcgp` to keep persistent data outside of version control

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684287d45e3c832faa897e6c37684daf