### PR TITLE
Add PTCGP setup guild test

### DIFF
--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -1,10 +1,11 @@
 import pytest
 
 
-from cogs import quiz, champion, wcr
+from cogs import quiz, champion, wcr, ptcgp
 from cogs.quiz.slash_commands import quiz_group
 from cogs.champion.slash_commands import champion_group, syncroles
 from cogs.wcr.slash_commands import wcr_group
+from cogs.ptcgp.slash_commands import ptcgp_group
 import cogs.quiz.cog as quiz_cog_mod
 import cogs.quiz.message_tracker as msg_mod
 from cogs.wcr.utils import load_wcr_data
@@ -61,3 +62,17 @@ async def test_wcr_setup_uses_main_guild(monkeypatch, bot):
     await wcr.setup(bot)
 
     assert called == [(wcr_group, bot.main_guild)]
+
+
+@pytest.mark.asyncio
+async def test_ptcgp_setup_uses_main_guild(monkeypatch, bot):
+    called = []
+
+    def fake_add(cmd, *, guild=None):
+        called.append((cmd, guild))
+
+    monkeypatch.setattr(bot.tree, "add_command", fake_add)
+
+    await ptcgp.setup(bot)
+
+    assert called == [(ptcgp_group, bot.main_guild)]


### PR DESCRIPTION
## Summary
- cover ptcgp setup with a new test ensuring command registration uses the main guild

## Testing
- `black . --quiet`
- `python -m py_compile tests/general/test_cogs_setup.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684287e2f5a0832f9056bfbdba12fffd