### PR TITLE
Verbessertes Fuzzy-Matching für /wcr name

### DIFF
--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -137,6 +137,30 @@ def test_resolve_unit_cross_language():
     cog.cog_unload()
 
 
+def test_resolve_unit_fuzzy_partial():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+
+    result = cog.resolve_unit("sylvanas", "de")
+    assert result is not None
+    unit_id, _, lang, _ = result
+    assert unit_id == 62
+    assert lang == "de"
+    cog.cog_unload()
+
+
+def test_resolve_unit_cross_language_fuzzy():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+
+    result = cog.resolve_unit("windrunner", "de")
+    assert result is not None
+    unit_id, _, lang, _ = result
+    assert unit_id == 62
+    assert lang == "en"
+    cog.cog_unload()
+
+
 @pytest.mark.asyncio
 async def test_select_view_timeout_disables_select():
     bot = DummyBot()


### PR DESCRIPTION
## Summary
- verbessertes Fuzzy-Matching für Namensauflösung in `resolve_unit`
- neue Tests für partielle und sprachübergreifende Suche

## Testing
- `black cogs/wcr/cog.py tests/wcr/test_wcr_cog.py`
- `python -m py_compile cogs/wcr/cog.py tests/wcr/test_wcr_cog.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428ad4e780832fbb9d7b19c2c7ad79