### PR TITLE
Add SSL verification toggle for PTCGP API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@
 bot_key=DEIN_DISCORD_TOKEN
 server_id=DEINE_SERVER_ID
 LOG_LEVEL=INFO
+# Optional: Ignoriert Zertifikatsfehler der PTCGP-API
+PTCGP_SKIP_SSL_VERIFY=0

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Die wichtigsten Variablen aus `.env`:
 bot_key=DISCORD_BOT_TOKEN
 server_id=DEINE_GUILD_ID
 LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
+# Bei Zertifikatsproblemen kann die Überprüfung für die PTCGP-API deaktiviert werden
+PTCGP_SKIP_SSL_VERIFY=0
 ```
 
 Beim ersten Start werden persistente Daten unter `data/pers/` angelegt (Punktedatenbank, Quiz-Historie etc.).

--- a/cogs/ptcgp/api.py
+++ b/cogs/ptcgp/api.py
@@ -1,4 +1,5 @@
 import aiohttp
+import os
 
 from log_setup import get_logger
 
@@ -8,11 +9,12 @@ logger = get_logger(__name__)
 async def fetch_all_cards(language: str) -> list[dict]:
     """Lade alle Karten für die angegebene Sprache über die REST-API."""
     cards: list[dict] = []
+    ssl_disabled = os.getenv("PTCGP_SKIP_SSL_VERIFY") == "1"
     async with aiohttp.ClientSession() as session:
         page = 1
         while True:
             url = f"https://api.tcgdex.dev/v2/tcg-pocket/{language}/cards?page={page}"
-            async with session.get(url) as resp:
+            async with session.get(url, ssl=False if ssl_disabled else None) as resp:
                 if resp.status != 200:
                     raise RuntimeError(f"HTTP {resp.status} beim Laden von {url}")
                 data = await resp.json()

--- a/tests/ptcgp/test_ptcgp_api.py
+++ b/tests/ptcgp/test_ptcgp_api.py
@@ -1,0 +1,43 @@
+import pytest
+
+import cogs.ptcgp.api as api_mod
+
+
+class DummyResponse:
+    def __init__(self):
+        self.status = 200
+        self.json_called = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        self.json_called = True
+        return []
+
+
+class DummySession:
+    def __init__(self, called):
+        self.called = called
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url, *, ssl=None):
+        self.called["ssl"] = ssl
+        return DummyResponse()
+
+
+@pytest.mark.asyncio
+async def test_fetch_respects_env(monkeypatch):
+    called = {}
+    monkeypatch.setenv("PTCGP_SKIP_SSL_VERIFY", "1")
+    monkeypatch.setattr(api_mod.aiohttp, "ClientSession", lambda: DummySession(called))
+    await api_mod.fetch_all_cards("en")
+    assert called["ssl"] is False


### PR DESCRIPTION
## Summary
- make SSL verification optional for Pokemon TCG Pocket API
- document new `PTCGP_SKIP_SSL_VERIFY` variable
- test env var handling for API requests

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842917bab10832f86d76bb582c60ffe