### PR TITLE
Ensure duel invite view is removed on start

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -209,6 +209,8 @@ class DuelInviteView(View):
             logger.debug(
                 f"[DuelInviteView] thread created: {thread.id if hasattr(thread, 'id') else 'N/A'}"
             )
+            if self.message:
+                await self.message.edit(view=None)
         except Exception as e:
             logger.error(f"Failed to create duel thread: {e}", exc_info=True)
             await champion_cog.update_user_score(

--- a/tests/quiz/test_duel.py
+++ b/tests/quiz/test_duel.py
@@ -170,7 +170,7 @@ async def test_start_duel_success(monkeypatch):
         (1, -20, "Quiz-Duell Einsatz"),
         (2, -20, "Quiz-Duell Einsatz"),
     ]
-    assert message.edited_view == "INIT"
+    assert message.edited_view is None
     assert run_called
 
 


### PR DESCRIPTION
## Summary
- remove invite view after duel start so buttons disappear
- update duel tests for new behaviour

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c68c74e8832fb7b68c35e379de73