### PR TITLE
Fix duel game generator access and add sequential test

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -267,7 +267,7 @@ class QuizDuelGame:
 
     async def run(self) -> None:
         """Run the duel until one player has enough wins."""
-        qg: QuestionGenerator = self.cog.bot.quiz_data[self.area]["question_generator"]
+        qg: QuestionGenerator = self.cog.bot.quiz_data[self.area].question_generator
         total_rounds = {"bo3": 3, "bo5": 5}.get(self.mode, 5)
         needed = total_rounds // 2 + 1
         logger.info(


### PR DESCRIPTION
## Summary
- adapt quiz duel game to use QuizAreaConfig attribute
- update dynamic duel test for dataclass configs
- add regression test that ensures sequential duel game sends a question

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842c68d86b4832f9cdc7195357251fd