### PR TITLE
Update DuelQuestionView timeout

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -25,7 +25,7 @@ class DuelQuestionView(View):
         correct_answers: list[str],
     ) -> None:
         """View handling question answers of a duel round."""
-        super().__init__(timeout=20)
+        super().__init__(timeout=30)
         self.challenger = challenger
         self.opponent = opponent
         self.players = {challenger.id, opponent.id}

--- a/tests/quiz/test_duel_question_view.py
+++ b/tests/quiz/test_duel_question_view.py
@@ -18,6 +18,8 @@ async def test_finish_sets_winner_and_disables_buttons():
     opponent = DummyMember(2)
     view = DuelQuestionView(challenger, opponent, ["yes"])
 
+    assert view.timeout == 30
+
     base = datetime.datetime.utcnow()
     view.responses = {
         challenger.id: ("yes", base + datetime.timedelta(seconds=1)),


### PR DESCRIPTION
## Summary
- extend DuelQuestionView timeout from 20 to 30 seconds
- verify updated timeout in duel question view test

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842d948b718832fbf2975d230e2bfe3