### PR TITLE
Handle late duel answers

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -97,6 +97,11 @@ class _DuelAnswerModal(Modal, title="Antwort eingeben"):
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         """Store the answer and finish if all players responded."""
+        if self.view.is_finished():
+            await interaction.response.send_message(
+                "Die Runde ist bereits beendet.", ephemeral=True
+            )
+            return
         self.view.responses[interaction.user.id] = (
             self.answer.value,
             interaction.created_at or datetime.datetime.utcnow(),

--- a/tests/quiz/test_duel_question_view.py
+++ b/tests/quiz/test_duel_question_view.py
@@ -2,7 +2,7 @@ import datetime
 import pytest
 
 
-from cogs.quiz.duel import DuelQuestionView
+from cogs.quiz.duel import DuelQuestionView, _DuelAnswerModal
 
 
 class DummyMember:
@@ -10,6 +10,21 @@ class DummyMember:
         self.id = uid
         self.display_name = f"user{uid}"
         self.mention = f"<@{uid}>"
+
+
+class DummyResponse:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, content, **kwargs):
+        self.sent.append((content, kwargs))
+
+
+class DummyInteraction:
+    def __init__(self, user):
+        self.user = user
+        self.response = DummyResponse()
+        self.created_at = datetime.datetime.utcnow()
 
 
 @pytest.mark.asyncio
@@ -28,3 +43,22 @@ async def test_finish_sets_winner_and_disables_buttons():
 
     assert view.winner_id == opponent.id
     assert all(child.disabled for child in view.children)
+
+
+@pytest.mark.asyncio
+async def test_modal_ignores_after_finish():
+    challenger = DummyMember(1)
+    opponent = DummyMember(2)
+    view = DuelQuestionView(challenger, opponent, ["yes"])
+
+    await view._finish()
+    modal = _DuelAnswerModal(view)
+    modal.answer._value = "foo"
+    inter = DummyInteraction(challenger)
+
+    await modal.on_submit(inter)
+
+    assert view.responses == {}
+    assert inter.response.sent == [
+        ("Die Runde ist bereits beendet.", {"ephemeral": True})
+    ]


### PR DESCRIPTION
## Summary
- ignore duel answers submitted after a view has finished
- test that late answers are rejected and don't modify responses

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d9493028832f9f90180192749499