### PR TITLE
Implement duel invite timeout notification

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -127,6 +127,9 @@ class DuelInviteView(View):
         if not self.accepted and self.message:
             logger.info("[DuelInviteView] invitation timed out")
             await self.message.edit(view=None)
+            await self.message.channel.send(
+                f"{self.challenger.mention}, deine Duellanfrage ist abgelaufen."
+            )
 
     @button(label="Annehmen", style=discord.ButtonStyle.success)
     async def accept(self, interaction: discord.Interaction, _: Button) -> None:

--- a/tests/quiz/test_duel.py
+++ b/tests/quiz/test_duel.py
@@ -230,6 +230,37 @@ async def test_start_duel_insufficient_points_opponent():
 
 
 @pytest.mark.asyncio
+async def test_invite_timeout_notifies():
+    class DummyChannel:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, msg, **kwargs):
+            self.sent.append(msg)
+
+    class DummyMessage:
+        def __init__(self, channel):
+            self.channel = channel
+            self.edited_view = "INIT"
+
+        async def edit(self, view=None):
+            self.edited_view = view
+
+    channel = DummyChannel()
+    message = DummyMessage(channel)
+    bot = DummyBot()
+    cog = DummyCog(bot)
+    challenger = DummyMember(1)
+    view = DuelInviteView(challenger, DuelConfig("area", 20, "bo3"), cog)
+    view.message = message
+
+    await view.on_timeout()
+
+    assert channel.sent == [f"{challenger.mention}, deine Duellanfrage ist abgelaufen."]
+    assert message.edited_view is None
+
+
+@pytest.mark.asyncio
 async def test_game_run_dynamic(monkeypatch):
     challenger = DummyMember(1)
     opponent = DummyMember(2)


### PR DESCRIPTION
## Summary
- notify the challenger when a duel invite times out
- test DuelInviteView timeout notification

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d94a4edc832fb34c5d328203bb25