### PR TITLE
Fix F811 in duel question view tests

### DIFF
--- a/tests/quiz/test_duel_question_view.py
+++ b/tests/quiz/test_duel_question_view.py
@@ -20,7 +20,7 @@ class DummyResponse:
         self.sent.append((content, kwargs))
 
 
-class DummyInteraction:
+class DummyDuelInteraction:
     def __init__(self, user):
         self.user = user
         self.response = DummyResponse()
@@ -56,7 +56,7 @@ async def test_modal_ignores_after_finish():
     await view._finish()
     modal = _DuelAnswerModal(view)
     modal.answer._value = "foo"
-    inter = DummyInteraction(challenger)
+    inter = DummyDuelInteraction(challenger)
 
     await modal.on_submit(inter)
 


### PR DESCRIPTION
## Summary
- rename `DummyInteraction` in duel question view test to avoid lint clash

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842e7cef878832fa38c7003853f6bbe