### PR TITLE
Add timeout option for quiz duels

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Beim ersten Start werden persistente Daten unter `data/pers/` angelegt (Punkteda
 | `/quiz time`          | Zeitfenster für automatische Fragen setzen *(Mod)*                  |
 | `/quiz threshold`     | Nachrichten-Schwelle für Auto-Fragen *(Mod)*                       |
 | `/quiz reset`         | Fragehistorie für diesen Channel löschen *(Mod)*                    |
-| `/quiz duel`          | Starte ein Quiz-Duell (bo3, bo5 oder dynamic)                        |
+| `/quiz duel`          | Starte ein Quiz-Duell (bo3, bo5 oder dynamic, optionaler Timeout) |
 
 Der Modus `dynamic` passt die Rundenzahl automatisch an und steht nur in Areas mit dynamischen Fragen (momentan `wcr`) zur Verfügung.
 

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -203,12 +203,15 @@ async def ask(interaction: discord.Interaction):
     name="duel", description="Starte ein Quiz-Duell (bo3, bo5, dynamic)"
 )
 @app_commands.describe(
-    punkte="Gesetzte Punkte", modus="Modus des Duells (bo3, bo5 oder dynamic)"
+    punkte="Gesetzte Punkte",
+    modus="Modus des Duells (bo3, bo5 oder dynamic)",
+    timeout="Antwortzeit in Sekunden (10–120)",
 )
 async def duel(
     interaction: discord.Interaction,
     punkte: app_commands.Range[int, 1, 10000],
     modus: Literal["bo3", "bo5", "dynamic"] = "bo3",
+    timeout: app_commands.Range[int, 10, 120] = 30,
 ):
     area = get_area_by_channel(interaction.client, interaction.channel.id)
     if not area:
@@ -237,7 +240,7 @@ async def duel(
         )
         return
 
-    cfg = DuelConfig(area=area, points=punkte, mode=modus)
+    cfg = DuelConfig(area=area, points=punkte, mode=modus, timeout=timeout)
     view = DuelInviteView(interaction.user, cfg, interaction.client.get_cog("QuizCog"))
     embed = discord.Embed(
         title="Quiz-Duell",

--- a/tests/quiz/test_duel_question_view.py
+++ b/tests/quiz/test_duel_question_view.py
@@ -31,7 +31,7 @@ class DummyDuelInteraction:
 async def test_finish_sets_winner_and_disables_buttons():
     challenger = DummyMember(1)
     opponent = DummyMember(2)
-    view = DuelQuestionView(challenger, opponent, ["yes"])
+    view = DuelQuestionView(challenger, opponent, ["yes"], 30)
 
     assert view.timeout == 30
 
@@ -51,7 +51,7 @@ async def test_finish_sets_winner_and_disables_buttons():
 async def test_modal_ignores_after_finish():
     challenger = DummyMember(1)
     opponent = DummyMember(2)
-    view = DuelQuestionView(challenger, opponent, ["yes"])
+    view = DuelQuestionView(challenger, opponent, ["yes"], 30)
 
     await view._finish()
     await view._finish()


### PR DESCRIPTION
## Summary
- allow customizing duel answer timeout via `DuelConfig`
- support optional `timeout` parameter for `/quiz duel`
- update `DuelQuestionView` and `QuizDuelGame` to respect the timeout
- document the new parameter
- adjust duel view tests

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f53647c8832f8df57db5c58fddbf