### PR TITLE
Fix for missing pytest-asyncio instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Persistente Daten liegen in `data/pers/` und sollten nicht ins Repository aufgen
 ## Entwicklung
 
 ```bash
+pip install -r requirements.txt  # installiert auch pytest-asyncio
 flake8       # Linting
 pytest -q    # Test Suite
 ```


### PR DESCRIPTION
## Summary
- mention dependency installation with pytest-asyncio in the dev section

## Testing
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f903e380832fb421bbb0a21657a5