### PR TITLE
Add ephemeral flags to champion mod commands

### DIFF
--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -32,7 +32,8 @@ async def give(
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     new_total = await cog.update_user_score(user.id, punkte, grund)
     await interaction.response.send_message(
-        f"✅ {user.mention} hat nun insgesamt {new_total} Punkte."
+        f"✅ {user.mention} hat nun insgesamt {new_total} Punkte.",
+        ephemeral=True,
     )
 
 
@@ -56,7 +57,8 @@ async def remove(
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     new_total = await cog.update_user_score(user.id, -punkte, grund)
     await interaction.response.send_message(
-        f"⚠️ {user.mention} hat nun insgesamt {new_total} Punkte."
+        f"⚠️ {user.mention} hat nun insgesamt {new_total} Punkte.",
+        ephemeral=True,
     )
 
 
@@ -84,7 +86,8 @@ async def set_points(
     delta = punkte - old_total
     new_total = await cog.update_user_score(user.id, delta, grund)
     await interaction.response.send_message(
-        f"🔧 {user.mention} wurde auf {new_total} Punkte gesetzt."
+        f"🔧 {user.mention} wurde auf {new_total} Punkte gesetzt.",
+        ephemeral=True,
     )
 
 
@@ -103,12 +106,14 @@ async def reset(interaction: discord.Interaction, user: discord.Member):
     old_total = await cog.data.get_total(str(user.id))
     if old_total <= 0:
         await interaction.response.send_message(
-            f"ℹ️ {user.mention} hat aktuell keine Punkte zum Zurücksetzen."
+            f"ℹ️ {user.mention} hat aktuell keine Punkte zum Zurücksetzen.",
+            ephemeral=True,
         )
         return
     await cog.update_user_score(user.id, -old_total, "Reset durch Mod")
     await interaction.response.send_message(
-        f"🔄 {user.mention} wurde auf 0 Punkte zurückgesetzt."
+        f"🔄 {user.mention} wurde auf 0 Punkte zurückgesetzt.",
+        ephemeral=True,
     )
 
 
@@ -152,7 +157,10 @@ async def myhistory(interaction: discord.Interaction):
         lines.append(f"📅 {date_str}: {sign}{delta} – {entry['reason']}")
 
     text = "\n".join(lines)
-    await interaction.response.send_message(f"📜 Dein Punkteverlauf:\n{text}")
+    await interaction.response.send_message(
+        f"📜 Dein Punkteverlauf:\n{text}",
+        ephemeral=True,
+    )
 
 
 @champion_group.command(
@@ -171,7 +179,8 @@ async def history(interaction: discord.Interaction, user: discord.Member):
 
     if not history_list:
         await interaction.response.send_message(
-            f"📭 {user.display_name} hat noch keine Historie."
+            f"📭 {user.display_name} hat noch keine Historie.",
+            ephemeral=True,
         )
         return
 
@@ -184,7 +193,8 @@ async def history(interaction: discord.Interaction, user: discord.Member):
 
     text = "\n".join(lines)
     await interaction.response.send_message(
-        f"📜 Punkteverlauf von {user.display_name}:\n{text}"
+        f"📜 Punkteverlauf von {user.display_name}:\n{text}",
+        ephemeral=True,
     )
 
 
@@ -338,7 +348,8 @@ async def clean(interaction: discord.Interaction):
                 )
 
     await interaction.followup.send(
-        f"🧹 Entfernte {removed} Einträge aus der Datenbank."
+        f"🧹 Entfernte {removed} Einträge aus der Datenbank.",
+        ephemeral=True,
     )
 
 
@@ -362,5 +373,6 @@ async def syncroles(interaction: discord.Interaction):
         processed += 1
 
     await interaction.followup.send(
-        f"🔄 Synchronisierte Rollen für {processed} Nutzer."
+        f"🔄 Synchronisierte Rollen für {processed} Nutzer.",
+        ephemeral=True,
     )

--- a/tests/champion/test_mod_ephemeral.py
+++ b/tests/champion/test_mod_ephemeral.py
@@ -1,0 +1,79 @@
+import pytest
+
+from cogs.champion.slash_commands import give, history
+
+
+class DummyBot:
+    def __init__(self):
+        self._cog = None
+
+    def get_cog(self, name):
+        return self._cog if name == "ChampionCog" else None
+
+
+class DummyCog:
+    def __init__(self):
+        self.updated = []
+        self.data = type("Data", (), {"get_history": self.get_history})()
+
+    async def update_user_score(self, user_id, delta, reason):
+        self.updated.append((user_id, delta, reason))
+        return 5
+
+    async def get_history(self, user_id, limit=10):
+        return []
+
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, msg, ephemeral=False):
+        self.messages.append((msg, ephemeral))
+
+
+class DummyInteraction:
+    def __init__(self, bot):
+        self.client = bot
+        self.user = DummyMember(999)
+        self.response = DummyResponse()
+        self.followup = DummyResponse()
+        self.guild = None
+
+
+class DummyMember:
+    def __init__(self, uid):
+        self.id = uid
+        self.mention = f"<@{uid}>"
+        self.display_name = f"User{uid}"
+
+
+@pytest.mark.asyncio
+async def test_give_sends_ephemeral_message():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+    target = DummyMember(1)
+
+    await give.callback(inter, target, 3, "reason")
+
+    assert cog.updated == [(1, 3, "reason")]
+    assert inter.response.messages
+    _, ephemeral = inter.response.messages[0]
+    assert ephemeral is True
+
+
+@pytest.mark.asyncio
+async def test_history_empty_is_ephemeral():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+    target = DummyMember(2)
+
+    await history.callback(inter, target)
+
+    assert inter.response.messages
+    _, ephemeral = inter.response.messages[0]
+    assert ephemeral is True

--- a/tests/champion/test_permissions.py
+++ b/tests/champion/test_permissions.py
@@ -48,7 +48,9 @@ async def test_moderator_only_blocks_non_mods():
     inter = DummyInteraction(False)
     assert await predicate(inter) is False
     assert inter.response.messages
-    assert "❌" in inter.response.messages[0][0]
+    msg, ephemeral = inter.response.messages[0]
+    assert "❌" in msg
+    assert ephemeral is True
 
 
 def test_mod_commands_have_default_permissions():

--- a/tests/champion/test_syncroles.py
+++ b/tests/champion/test_syncroles.py
@@ -28,8 +28,8 @@ class DummyFollowup:
     def __init__(self):
         self.sent = []
 
-    async def send(self, message):
-        self.sent.append(message)
+    async def send(self, message, ephemeral=False):
+        self.sent.append((message, ephemeral))
 
 
 class DummyInteraction:
@@ -64,4 +64,6 @@ async def test_syncroles_processes_all_users(monkeypatch, tmp_path):
 
     assert set(called) == {("1", 5), ("2", 3)}
     assert inter.followup.sent
+    msg, ephemeral = inter.followup.sent[0]
+    assert ephemeral is True
     await cog.data.close()


### PR DESCRIPTION
## Summary
- make mod slash commands in ChampionCog respond ephemerally
- adjust permission and syncroles tests
- add new tests for ephemeral behaviour of mod commands

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435134600c832fb4707e50f5b08e15