### PR TITLE
Implement auto-close scheduling in questions

### DIFF
--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -92,6 +92,9 @@ class QuestionManager:
             f"[QuestionManager] Nachricht ID {sent_msg.id} an Channel {channel.id} gesendet."
         )
 
+        delay = max((end_time - datetime.datetime.utcnow()).total_seconds(), 0)
+        self.cog._track_task(self.cog.closer.auto_close(area, delay))
+
         qinfo = QuestionInfo(
             message_id=sent_msg.id,
             end_time=end_time,


### PR DESCRIPTION
## Summary
- start auto-close timer in `QuestionManager.ask_question`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684350f27bbc832f96268ec2fa60540a