### PR TITLE
Add channel mapping to MessageTracker

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -91,6 +91,9 @@ def load_quiz_config(bot: commands.Bot):
 
     logger.info(f"[bot] Quiz-Konfiguration geladen: {list(bot.quiz_data.keys())}")
 
+    if hasattr(bot, "quiz_cog") and hasattr(bot.quiz_cog, "tracker"):
+        bot.quiz_cog.tracker.update_mapping()
+
 
 class MyBot(commands.Bot):
     def __init__(self) -> None:

--- a/tests/quiz/test_load_quiz_config.py
+++ b/tests/quiz/test_load_quiz_config.py
@@ -71,3 +71,33 @@ def test_single_state_manager(tmp_path, monkeypatch):
     state1 = bot.quiz_data["wcr"].question_state
     state2 = bot.quiz_data["d4"].question_state
     assert state1 is state2
+
+
+def test_reload_updates_tracker(tmp_path, monkeypatch):
+    cfg1 = {"area": {"channel_id": 1, "window_timer": 5, "language": "de"}}
+    cfg2 = {"area": {"channel_id": 2, "window_timer": 5, "language": "de"}}
+
+    cfg_file = tmp_path / "areas.json"
+    state_file = tmp_path / "state.json"
+
+    monkeypatch.setattr("bot.QUIZ_CONFIG_PATH", str(cfg_file))
+    monkeypatch.setattr("bot.QUESTION_STATE_PATH", str(state_file))
+
+    from cogs.quiz.message_tracker import MessageTracker
+
+    class DummyCog:
+        def __init__(self, bot):
+            self.tracker = MessageTracker(bot, None)
+
+    bot = DummyBot()
+    bot.quiz_cog = DummyCog(bot)
+
+    with open(cfg_file, "w", encoding="utf-8") as f:
+        json.dump(cfg1, f)
+    load_quiz_config(bot)
+    assert bot.quiz_cog.tracker.channel_to_area == {1: "area"}
+
+    with open(cfg_file, "w", encoding="utf-8") as f:
+        json.dump(cfg2, f)
+    load_quiz_config(bot)
+    assert bot.quiz_cog.tracker.channel_to_area == {2: "area"}

--- a/tests/quiz/test_message_tracker.py
+++ b/tests/quiz/test_message_tracker.py
@@ -44,6 +44,12 @@ class DummyBot:
         self.quiz_data = {"area1": QuizAreaConfig(channel_id=123, activity_threshold=3)}
 
 
+def test_channel_map_created():
+    bot = DummyBot()
+    tracker = MessageTracker(bot, None)
+    assert tracker.channel_to_area == {123: "area1"}
+
+
 def test_register_message_increments_and_triggers(monkeypatch, patch_logged_task):
     bot = DummyBot()
     tracker = MessageTracker(bot, bot.quiz_cog.manager.ask_question)


### PR DESCRIPTION
## Summary
- keep a map of channel IDs to quiz areas in `MessageTracker`
- rebuild the map when quiz config is loaded
- adjust tracker to use the new mapping
- test that the mapping works and is updated

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684350ee2284832fab20bc1980e3e367