### PR TITLE
Add async locking to question state updates

### DIFF
--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -64,7 +64,7 @@ class QuizCog(commands.Cog):
         self.restorer = QuestionRestorer(
             bot=self.bot, state_manager=self.state, create_task=self._track_task
         )
-        self.restorer.restore_all()
+        self._track_task(self.restorer.restore_all())
 
         for area, cfg in self.bot.quiz_data.items():
             active = cfg.active if hasattr(cfg, "active") else cfg.get("active")

--- a/cogs/quiz/question_closer.py
+++ b/cogs/quiz/question_closer.py
@@ -50,7 +50,7 @@ class QuestionCloser:
             )
 
         self.bot.quiz_cog.current_questions.pop(area, None)
-        self.state.clear_active_question(area)
+        await self.state.clear_active_question(area)
         self.bot.quiz_cog.tracker.set_initialized(cfg.channel_id)
 
     async def auto_close(self, area: str, delay: float) -> None:

--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -26,7 +26,7 @@ class QuestionGenerator:
         """Return the dynamic provider for ``area`` if available."""
         return self.dynamic_providers.get(area)
 
-    def generate(
+    async def generate(
         self, area: str | None = None, language: str = "de"
     ) -> Dict[str, Any] | None:
         """Generate a new question for ``area`` in the given ``language``."""
@@ -70,7 +70,7 @@ class QuestionGenerator:
         # store only the question ID in history to avoid unhashable entries
         question_id = question.get("id")
         if question_id is not None:
-            self.state_manager.mark_question_as_asked(area, question_id)
+            await self.state_manager.mark_question_as_asked(area, question_id)
         else:
             logger.warning(
                 f"[QuestionGenerator] Frage ohne ID in '{area}' kann nicht in der Historie gespeichert werden."

--- a/cogs/quiz/question_manager.py
+++ b/cogs/quiz/question_manager.py
@@ -64,7 +64,7 @@ class QuestionManager:
         qg = cfg.question_generator
 
         language = cfg.language
-        question = qg.generate(area, language=language)
+        question = await qg.generate(area, language=language)
         if not question:
             logger.warning(f"[QuestionManager] Keine Frage generiert für '{area}'.")
             return
@@ -103,6 +103,6 @@ class QuestionManager:
         self.cog.answered_users[area].clear()
         self.cog.tracker.reset(channel.id)
         self.cog.awaiting_activity.pop(channel.id, None)
-        self.cog.state.set_active_question(area, qinfo)
+        await self.cog.state.set_active_question(area, qinfo)
 
         logger.info(f"[QuestionManager] Frage gesendet in '{area}': {frage_text}")

--- a/cogs/quiz/question_restorer.py
+++ b/cogs/quiz/question_restorer.py
@@ -18,7 +18,7 @@ class QuestionRestorer:
         self._create_task = create_task
         self.tasks: list[asyncio.Task] = []
 
-    def restore_all(self) -> None:
+    async def restore_all(self) -> None:
         """Recreate all still active questions from persisted state."""
         for area, _ in self.bot.quiz_data.items():
             active = self.state.get_active_question(area)
@@ -35,7 +35,7 @@ class QuestionRestorer:
                     task = self._create_task(self.repost_question(area, active))
                     self.tasks.append(task)
                 else:
-                    self.state.clear_active_question(area)
+                    await self.state.clear_active_question(area)
             except Exception as e:
                 logger.error(
                     f"[Restorer] Fehler beim Wiederherstellen von '{area}': {e}",
@@ -58,7 +58,7 @@ class QuestionRestorer:
                 logger.warning(
                     f"[Restorer] Ursprüngliche Nachricht für '{area}' nicht mehr vorhanden – lösche Zustand."
                 )
-                self.state.clear_active_question(area)
+                await self.state.clear_active_question(area)
                 return
 
             if msg.embeds and (
@@ -69,7 +69,7 @@ class QuestionRestorer:
                 logger.info(
                     f"[Restorer] Frage in '{area}' war bereits rot markiert oder hatte Footer – wird nicht wiederhergestellt."
                 )
-                self.state.clear_active_question(area)
+                await self.state.clear_active_question(area)
                 return
 
             correct_answers = qinfo.answers
@@ -108,7 +108,7 @@ class QuestionRestorer:
             )
         except Exception as e:
             logger.error(f"[Restorer] Fehler in '{area}': {e}", exc_info=True)
-            self.state.clear_active_question(area)
+            await self.state.clear_active_question(area)
 
     def cancel_all(self) -> None:
         """Cancel all running tasks created by the restorer."""

--- a/cogs/quiz/scheduler.py
+++ b/cogs/quiz/scheduler.py
@@ -59,7 +59,9 @@ class QuizScheduler:
                     seconds=random.uniform(0, 10)
                 )
 
-                self.bot.quiz_cog.state.set_schedule(self.area, post_time, window_end)
+                await self.bot.quiz_cog.state.set_schedule(
+                    self.area, post_time, window_end
+                )
 
                 self.logger.info(
                     f"[Scheduler] Neues Zeitfenster für '{self.area}' bis {window_end:%H:%M}. "
@@ -79,7 +81,7 @@ class QuizScheduler:
                 f"[Scheduler] Wache auf – prüfe Bedingungen für '{self.area}'..."
             )
             await self.prepare_question(self.area, window_end)
-            self.bot.quiz_cog.state.clear_schedule(self.area)
+            await self.bot.quiz_cog.state.clear_schedule(self.area)
 
             await asyncio.sleep(
                 max((window_end - datetime.datetime.utcnow()).total_seconds(), 0)

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -339,7 +339,7 @@ async def reset(interaction: discord.Interaction):
         return
 
     state = interaction.client.quiz_data[area].question_state
-    state.reset_asked_questions(area)
+    await state.reset_asked_questions(area)
     await interaction.response.send_message(
         f"♻️ Frageverlauf für **{area}** wurde zurückgesetzt.", ephemeral=True
     )

--- a/tests/quiz/test_question_state_manager.py
+++ b/tests/quiz/test_question_state_manager.py
@@ -5,7 +5,11 @@ import datetime
 from cogs.quiz.question_state import QuestionStateManager, QuestionInfo
 
 
-def test_set_active_question(tmp_path):
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_set_active_question(tmp_path):
     state_file = tmp_path / "state.json"
     manager = QuestionStateManager(str(state_file))
     question = QuestionInfo(
@@ -14,7 +18,7 @@ def test_set_active_question(tmp_path):
         answers=["a"],
         frage="foo",
     )
-    manager.set_active_question("area1", question)
+    await manager.set_active_question("area1", question)
 
     restored = manager.get_active_question("area1")
     assert restored == question
@@ -24,11 +28,12 @@ def test_set_active_question(tmp_path):
     assert saved["active"]["area1"] == question.to_dict()
 
 
-def test_mark_question_as_asked(tmp_path):
+@pytest.mark.asyncio
+async def test_mark_question_as_asked(tmp_path):
     state_file = tmp_path / "state.json"
     manager = QuestionStateManager(str(state_file))
-    manager.mark_question_as_asked("area1", 42)
-    manager.mark_question_as_asked("area1", 42)
+    await manager.mark_question_as_asked("area1", 42)
+    await manager.mark_question_as_asked("area1", 42)
 
     assert manager.get_asked_questions("area1") == [42]
 
@@ -37,11 +42,12 @@ def test_mark_question_as_asked(tmp_path):
     assert saved["history"]["area1"] == [42]
 
 
-def test_filter_unasked_questions(tmp_path):
+@pytest.mark.asyncio
+async def test_filter_unasked_questions(tmp_path):
     state_file = tmp_path / "state.json"
     manager = QuestionStateManager(str(state_file))
-    manager.mark_question_as_asked("area1", 1)
-    manager.mark_question_as_asked("area1", 3)
+    await manager.mark_question_as_asked("area1", 1)
+    await manager.mark_question_as_asked("area1", 3)
 
     questions = [
         {"id": 1},

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -47,7 +47,15 @@ class DummyState:
 async def test_scheduler_start_and_stop(monkeypatch, patch_logged_task, bot):
     patch_logged_task(quiz_cog_mod, msg_mod)
     monkeypatch.setattr(scheduler_mod, "create_logged_task", fake_task_scheduler)
-    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", lambda self: None)
+
+    async def dummy_restore(self):
+        return None
+
+    monkeypatch.setattr(
+        quiz_cog_mod.QuestionRestorer,
+        "restore_all",
+        dummy_restore,
+    )
 
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
     bot.quiz_data = {
@@ -93,7 +101,11 @@ class DummyInteraction:
 async def test_enable_starts_and_disable_stops(monkeypatch, patch_logged_task, bot):
     patch_logged_task(quiz_cog_mod, msg_mod)
     monkeypatch.setattr(scheduler_mod, "create_logged_task", fake_task_scheduler)
-    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", lambda self: None)
+
+    async def dummy_restore(self):
+        return None
+
+    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", dummy_restore)
     monkeypatch.setattr(slash_mod, "save_area_config", lambda b: None)
 
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}

--- a/tests/quiz/test_scheduler_persistence.py
+++ b/tests/quiz/test_scheduler_persistence.py
@@ -38,7 +38,11 @@ def fake_task_scheduler_2(coro, logger):
 async def test_scheduler_resume(monkeypatch, patch_logged_task, tmp_path):
     patch_logged_task(quiz_cog_mod, msg_mod)
     monkeypatch.setattr(scheduler_mod, "create_logged_task", fake_task_scheduler)
-    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", lambda self: None)
+
+    async def dummy_restore(self):
+        return None
+
+    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", dummy_restore)
 
     async def dummy_prepare(self, area, end):
         raise asyncio.CancelledError()
@@ -89,7 +93,11 @@ async def test_scheduler_resume(monkeypatch, patch_logged_task, tmp_path):
     # simulate restart
     patch_logged_task(quiz_cog_mod, msg_mod)
     monkeypatch.setattr(scheduler_mod, "create_logged_task", fake_task_scheduler_2)
-    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", lambda self: None)
+
+    async def dummy_restore2(self):
+        return None
+
+    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", dummy_restore2)
 
     bot2 = DummyBot()
     bot2.data = bot.data


### PR DESCRIPTION
## Summary
- ensure saving question state uses an `asyncio.Lock`
- update all state-modifying methods to `async` and await save
- adapt quiz modules to await the new methods
- adjust unit tests for async API

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684350f54b38832f9486e4791f086dac