### PR TITLE
Fix quiz duel question generation

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import datetime
 
 from .utils import check_answer
+import inspect
 from .question_generator import QuestionGenerator
 from log_setup import get_logger
 
@@ -381,6 +382,8 @@ class QuizDuelGame:
         # classic sequential modes
         for rnd in range(1, total_rounds + 1):
             question = qg.generate(self.area)
+            if inspect.isawaitable(question):
+                question = await question
             if not question:
                 await self.thread.send("Keine Frage generiert. Duell abgebrochen.")
                 champion_cog = self.cog.bot.get_cog("ChampionCog")


### PR DESCRIPTION
## Summary
- support both sync and async question generators in quiz duels

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684550a6dc6c832f96eaea7ddc22855a