### PR TITLE
Update score command ephemeral

### DIFF
--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -128,10 +128,14 @@ async def score(interaction: discord.Interaction, user: discord.Member | None = 
     target = user or interaction.user
     total = await cog.data.get_total(str(target.id))
     if user is None or target.id == interaction.user.id:
-        await interaction.response.send_message(f"🏅 Du hast aktuell {total} Punkte.")
+        await interaction.response.send_message(
+            f"🏅 Du hast aktuell {total} Punkte.",
+            ephemeral=True,
+        )
     else:
         await interaction.response.send_message(
-            f"🏅 {target.display_name} hat aktuell {total} Punkte."
+            f"🏅 {target.display_name} hat aktuell {total} Punkte.",
+            ephemeral=True,
         )
 
 

--- a/tests/champion/test_mod_ephemeral.py
+++ b/tests/champion/test_mod_ephemeral.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cogs.champion.slash_commands import give, history
+from cogs.champion.slash_commands import give, history, score
 
 
 class DummyBot:
@@ -14,7 +14,11 @@ class DummyBot:
 class DummyCog:
     def __init__(self):
         self.updated = []
-        self.data = type("Data", (), {"get_history": self.get_history})()
+        self.data = type(
+            "Data",
+            (),
+            {"get_history": self.get_history, "get_total": self.get_total},
+        )()
 
     async def update_user_score(self, user_id, delta, reason):
         self.updated.append((user_id, delta, reason))
@@ -22,6 +26,9 @@ class DummyCog:
 
     async def get_history(self, user_id, limit=10):
         return []
+
+    async def get_total(self, user_id):
+        return 0
 
 
 class DummyResponse:
@@ -73,6 +80,20 @@ async def test_history_empty_is_ephemeral():
     target = DummyMember(2)
 
     await history.callback(inter, target)
+
+    assert inter.response.messages
+    _, ephemeral = inter.response.messages[0]
+    assert ephemeral is True
+
+
+@pytest.mark.asyncio
+async def test_score_is_ephemeral():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+
+    await score.callback(inter, None)
 
     assert inter.response.messages
     _, ephemeral = inter.response.messages[0]


### PR DESCRIPTION
## Summary
- keep score results private
- check ephemeral behavior

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456d23d690832f852b2b27319299a6