### PR TITLE
Show total score in champion history

### DIFF
--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -144,6 +144,7 @@ async def myhistory(interaction: discord.Interaction):
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     user_id_str = str(interaction.user.id)
     history_list = await cog.data.get_history(user_id_str, limit=10)
+    total = await cog.data.get_total(user_id_str)
 
     if not history_list:
         await interaction.response.send_message("📭 Du hast noch keine Historie.")
@@ -157,6 +158,7 @@ async def myhistory(interaction: discord.Interaction):
         lines.append(f"📅 {date_str}: {sign}{delta} – {entry['reason']}")
 
     text = "\n".join(lines)
+    text += f"\nAktueller Stand: {total} Punkte."
     await interaction.response.send_message(
         f"📜 Dein Punkteverlauf:\n{text}",
         ephemeral=True,
@@ -176,6 +178,7 @@ async def history(interaction: discord.Interaction, user: discord.Member):
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     user_id_str = str(user.id)
     history_list = await cog.data.get_history(user_id_str, limit=10)
+    total = await cog.data.get_total(user_id_str)
 
     if not history_list:
         await interaction.response.send_message(
@@ -192,6 +195,7 @@ async def history(interaction: discord.Interaction, user: discord.Member):
         lines.append(f"📅 {date_str}: {sign}{delta} – {entry['reason']}")
 
     text = "\n".join(lines)
+    text += f"\nAktueller Stand: {total} Punkte."
     await interaction.response.send_message(
         f"📜 Punkteverlauf von {user.display_name}:\n{text}",
         ephemeral=True,

--- a/tests/champion/test_history_total.py
+++ b/tests/champion/test_history_total.py
@@ -1,0 +1,63 @@
+import pytest
+
+from cogs.champion.slash_commands import myhistory
+
+
+class DummyBot:
+    def __init__(self):
+        self._cog = None
+
+    def get_cog(self, name):
+        return self._cog if name == "ChampionCog" else None
+
+
+class DummyCog:
+    def __init__(self):
+        self.data = type(
+            "Data", (), {"get_history": self.get_history, "get_total": self.get_total}
+        )()
+
+    async def get_history(self, user_id, limit=10):
+        return [{"delta": 2, "reason": "test", "date": "2023-01-01"}]
+
+    async def get_total(self, user_id):
+        return 5
+
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, msg, ephemeral=False):
+        self.messages.append((msg, ephemeral))
+
+
+class DummyMember:
+    def __init__(self, uid):
+        self.id = uid
+        self.mention = f"<@{uid}>"
+        self.display_name = f"User{uid}"
+
+
+class DummyInteraction:
+    def __init__(self, bot):
+        self.client = bot
+        self.user = DummyMember(999)
+        self.response = DummyResponse()
+        self.followup = DummyResponse()
+        self.guild = None
+
+
+@pytest.mark.asyncio
+async def test_myhistory_includes_total():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+
+    await myhistory.callback(inter)
+
+    assert inter.response.messages
+    msg, ephemeral = inter.response.messages[0]
+    assert "Aktueller Stand: 5 Punkte." in msg
+    assert ephemeral is True

--- a/tests/champion/test_mod_ephemeral.py
+++ b/tests/champion/test_mod_ephemeral.py
@@ -14,7 +14,11 @@ class DummyBot:
 class DummyCog:
     def __init__(self):
         self.updated = []
-        self.data = type("Data", (), {"get_history": self.get_history})()
+        self.data = type(
+            "Data",
+            (),
+            {"get_history": self.get_history, "get_total": self.get_total},
+        )()
 
     async def update_user_score(self, user_id, delta, reason):
         self.updated.append((user_id, delta, reason))
@@ -22,6 +26,9 @@ class DummyCog:
 
     async def get_history(self, user_id, limit=10):
         return []
+
+    async def get_total(self, user_id):
+        return 0
 
 
 class DummyResponse:


### PR DESCRIPTION
## Summary
- include total score in `/champion myhistory` and `/champion history`
- cover new behaviour with unit tests
- adjust existing tests for dummy data accessors

## Testing
- `black . --quiet`
- `python -m py_compile cogs/champion/slash_commands.py tests/champion/test_history_total.py tests/champion/test_mod_ephemeral.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456d1d0e04832fb56d949df8e91195