### PR TITLE
Support custom best-of mode for quiz duels

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Beim ersten Start werden persistente Daten unter `data/pers/` angelegt (Punkteda
 | `/quiz time`          | Zeitfenster für automatische Fragen setzen *(Mod)*                  |
 | `/quiz threshold`     | Nachrichten-Schwelle für Auto-Fragen *(Mod)*                       |
 | `/quiz reset`         | Fragehistorie für diesen Channel löschen *(Mod)*                    |
-| `/quiz duel`          | Starte ein Quiz-Duell (bo3, bo5 oder dynamic, optionaler Timeout). Nach jeder Runde werden Lösung, Antworten und Reaktionszeiten angezeigt |
+| `/quiz duel`          | Starte ein Quiz-Duell (Best‑of‑X oder dynamic, optionaler Timeout). Nach jeder Runde werden Lösung, Antworten und Reaktionszeiten angezeigt |
 
 Der Modus `dynamic` passt die Rundenzahl automatisch an und steht nur in Areas mit dynamischen Fragen (momentan `wcr`) zur Verfügung.
 

--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -17,6 +17,7 @@ class DuelConfig:
     points: int
     mode: str
     timeout: int = 30
+    best_of: int | None = None
 
 
 class DuelQuestionView(View):
@@ -283,6 +284,7 @@ class DuelInviteView(View):
             self.cfg.mode,
             self.message,
             self.cfg.timeout,
+            self.cfg.best_of,
         )
         await game.run()
         self.stop()
@@ -300,6 +302,7 @@ class QuizDuelGame:
         mode: str,
         invite_message: discord.Message | None = None,
         timeout: int = 30,
+        best_of: int | None = None,
     ) -> None:
         """Hold state for an ongoing duel game."""
 
@@ -312,6 +315,7 @@ class QuizDuelGame:
         self.pot = pot
         self.invite_message = invite_message
         self.timeout = timeout
+        self.best_of = best_of
         self.stake = pot // 2
         self.scores = {challenger.id: 0, opponent.id: 0}
         self.winner_id: int | None = None
@@ -319,13 +323,11 @@ class QuizDuelGame:
     async def run(self) -> None:
         """Run the duel until one player has enough wins."""
         qg: QuestionGenerator = self.cog.bot.quiz_data[self.area].question_generator
-        total_rounds = {"bo3": 3, "bo5": 5}.get(self.mode, 5)
-        needed = total_rounds // 2 + 1
-        logger.info(
-            f"QuizDuelGame started between {self.challenger} and {self.opponent} mode={self.mode} rounds={total_rounds}"
-        )
 
         if self.mode == "dynamic":
+            logger.info(
+                f"QuizDuelGame started between {self.challenger} and {self.opponent} mode=dynamic"
+            )
             provider = qg.get_dynamic_provider(self.area)
             if not provider:
                 await self.thread.send("Keine Frage generiert. Duell abgebrochen.")
@@ -440,6 +442,11 @@ class QuizDuelGame:
             return
 
         # classic sequential modes
+        total_rounds = self.best_of or 5
+        needed = total_rounds // 2 + 1
+        logger.info(
+            f"QuizDuelGame started between {self.challenger} and {self.opponent} mode=box rounds={total_rounds}"
+        )
         for rnd in range(1, total_rounds + 1):
             question = qg.generate(self.area)
             if inspect.isawaitable(question):

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -200,17 +200,19 @@ async def ask(interaction: discord.Interaction):
 
 
 @quiz_group.command(
-    name="duel", description="Starte ein Quiz-Duell (bo3, bo5, dynamic)"
+    name="duel", description="Starte ein Quiz-Duell (Best-of-X oder dynamic)"
 )
 @app_commands.describe(
     punkte="Gesetzte Punkte",
-    modus="Modus des Duells (bo3, bo5 oder dynamic)",
+    modus="Modus des Duells (box oder dynamic)",
+    best_of="Rundenanzahl für box-Modus",
     timeout="Antwortzeit in Sekunden (10–120)",
 )
 async def duel(
     interaction: discord.Interaction,
     punkte: app_commands.Range[int, 1, 10000],
-    modus: Literal["bo3", "bo5", "dynamic"] = "bo3",
+    modus: Literal["box", "dynamic"] = "box",
+    best_of: app_commands.Range[int, 3, 15] | None = None,
     timeout: app_commands.Range[int, 10, 120] = 30,
 ):
     area = get_area_by_channel(interaction.client, interaction.channel.id)
@@ -227,6 +229,12 @@ async def duel(
         )
         return
 
+    if modus == "box" and best_of is None:
+        await interaction.response.send_message(
+            "❌ Bitte gib die Rundenzahl an.", ephemeral=True
+        )
+        return
+
     champion_cog = interaction.client.get_cog("ChampionCog")
     if champion_cog is None:
         await interaction.response.send_message(
@@ -240,7 +248,9 @@ async def duel(
         )
         return
 
-    cfg = DuelConfig(area=area, points=punkte, mode=modus, timeout=timeout)
+    cfg = DuelConfig(
+        area=area, points=punkte, mode=modus, timeout=timeout, best_of=best_of
+    )
     view = DuelInviteView(interaction.user, cfg, interaction.client.get_cog("QuizCog"))
     embed = discord.Embed(
         title="Quiz-Duell",
@@ -248,7 +258,10 @@ async def duel(
         color=discord.Color.orange(),
     )
     embed.add_field(name="Einsatz", value=f"{punkte} Punkte")
-    embed.add_field(name="Modus", value=modus)
+    if modus == "box":
+        embed.add_field(name="Modus", value=f"Best of {best_of}")
+    else:
+        embed.add_field(name="Modus", value="dynamic")
     embed.add_field(name="Zeitlimit", value=f"{timeout}s")
     msg = await interaction.channel.send(embed=embed, view=view)
     view.message = msg

--- a/tests/quiz/test_duel.py
+++ b/tests/quiz/test_duel.py
@@ -112,7 +112,9 @@ async def test_finish_awards_pot_to_winner():
     challenger = DummyMember(1)
     opponent = DummyMember(2)
     thread = DummyThread()
-    game = QuizDuelGame(cog, thread, "area", challenger, opponent, 20, "bo3", None)
+    game = QuizDuelGame(
+        cog, thread, "area", challenger, opponent, 20, "box", None, best_of=3
+    )
     game.scores = {1: 2, 2: 1}
 
     await game._finish()
@@ -128,7 +130,9 @@ async def test_finish_refunds_on_tie():
     challenger = DummyMember(1)
     opponent = DummyMember(2)
     thread = DummyThread()
-    game = QuizDuelGame(cog, thread, "area", challenger, opponent, 20, "bo3", None)
+    game = QuizDuelGame(
+        cog, thread, "area", challenger, opponent, 20, "box", None, best_of=3
+    )
     game.scores = {1: 1, 2: 1}
 
     await game._finish()
@@ -147,7 +151,9 @@ async def test_finish_handles_missing_champion():
     challenger = DummyMember(1)
     opponent = DummyMember(2)
     thread = DummyThread()
-    game = QuizDuelGame(cog, thread, "area", challenger, opponent, 20, "bo3", None)
+    game = QuizDuelGame(
+        cog, thread, "area", challenger, opponent, 20, "box", None, best_of=3
+    )
     game.scores = {1: 2, 2: 1}
 
     await game._finish()
@@ -164,7 +170,7 @@ async def test_start_duel_success(monkeypatch):
     challenger = DummyMember(1)
     opponent = DummyMember(2)
     message = DummyMessage()
-    view = DuelInviteView(challenger, DuelConfig("area", 20, "bo3"), cog)
+    view = DuelInviteView(challenger, DuelConfig("area", 20, "box", best_of=3), cog)
     view.message = message
 
     run_called = []
@@ -190,7 +196,7 @@ async def test_start_duel_no_champion_system():
     bot = DummyBot(champion=False)
     cog = DummyCog(bot)
     message = DummyMessage()
-    view = DuelInviteView(DummyMember(1), DuelConfig("area", 20, "bo3"), cog)
+    view = DuelInviteView(DummyMember(1), DuelConfig("area", 20, "box", best_of=3), cog)
     view.message = message
     interaction = DummyInteraction(DummyMember(2))
 
@@ -208,7 +214,7 @@ async def test_start_duel_insufficient_points_challenger():
     cog = DummyCog(bot)
     message = DummyMessage()
     challenger = DummyMember(1)
-    view = DuelInviteView(challenger, DuelConfig("area", 20, "bo3"), cog)
+    view = DuelInviteView(challenger, DuelConfig("area", 20, "box", best_of=3), cog)
     view.message = message
     interaction = DummyInteraction(DummyMember(2))
 
@@ -227,7 +233,7 @@ async def test_start_duel_insufficient_points_opponent():
     cog = DummyCog(bot)
     message = DummyMessage()
     challenger = DummyMember(1)
-    view = DuelInviteView(challenger, DuelConfig("area", 20, "bo3"), cog)
+    view = DuelInviteView(challenger, DuelConfig("area", 20, "box", best_of=3), cog)
     view.message = message
     interaction = DummyInteraction(DummyMember(2))
 
@@ -252,7 +258,7 @@ async def test_start_duel_thread_fail(monkeypatch):
     monkeypatch.setattr(DummyMessage, "create_thread", fail_thread)
 
     challenger = DummyMember(1)
-    view = DuelInviteView(challenger, DuelConfig("area", 20, "bo3"), cog)
+    view = DuelInviteView(challenger, DuelConfig("area", 20, "box", best_of=3), cog)
     view.message = message
     view.accepted = True
     interaction = DummyInteraction(DummyMember(2))
@@ -291,10 +297,10 @@ async def test_invite_timeout_notifies():
     bot = DummyBot()
     cog = DummyCog(bot)
     challenger = DummyMember(1)
-    view = DuelInviteView(challenger, DuelConfig("area", 20, "bo3"), cog)
+    view = DuelInviteView(challenger, DuelConfig("area", 20, "box", best_of=3), cog)
     channel = DummyChannel()
     message = DummyMessage(channel=channel)
-    view = DuelInviteView(DummyMember(1), DuelConfig("area", 5, "bo3"), cog)
+    view = DuelInviteView(DummyMember(1), DuelConfig("area", 5, "box", best_of=3), cog)
     view.message = message
 
     await view.on_timeout()
@@ -458,7 +464,9 @@ async def test_game_run_sequential_sends_question():
     challenger = DummyMember(1)
     opponent = DummyMember(2)
     thread = DummyRunThread()
-    game = QuizDuelGame(cog, thread, "area", challenger, opponent, 20, "bo3", None)
+    game = QuizDuelGame(
+        cog, thread, "area", challenger, opponent, 20, "box", None, best_of=3
+    )
 
     await game.run()
 
@@ -502,7 +510,9 @@ async def test_game_run_fetches_user_when_cache_empty(monkeypatch):
     monkeypatch.setattr("cogs.quiz.duel.DuelQuestionView", AutoView)
 
     thread = DummyRunThread()
-    game = QuizDuelGame(cog, thread, "area", challenger, opponent, 20, "bo3", None)
+    game = QuizDuelGame(
+        cog, thread, "area", challenger, opponent, 20, "box", None, best_of=3
+    )
     game.scores = {challenger.id: 1, opponent.id: 1}
     await game.run()
 
@@ -527,7 +537,9 @@ async def test_finish_fetches_user_when_cache_empty():
     challenger = DummyMember(1)
     opponent = DummyMember(2)
     thread = DummyThread()
-    game = QuizDuelGame(cog, thread, "area", challenger, opponent, 20, "bo3", None)
+    game = QuizDuelGame(
+        cog, thread, "area", challenger, opponent, 20, "box", None, best_of=3
+    )
     game.scores = {1: 2, 2: 1}
 
     await game._finish()


### PR DESCRIPTION
## Summary
- allow `/quiz duel` to specify custom rounds via `best_of`
- extend `DuelConfig` and `QuizDuelGame` to store and use `best_of`
- update duel slash command and invitation text
- document new behaviour in the README
- adjust duel tests to new parameter

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456d0cee2c832fb474d48bfb265717