### PR TITLE
Track dynamic duel questions

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -348,7 +348,10 @@ class QuizDuelGame:
                 await self.thread.edit(archived=True)
                 return
 
+            state_manager = qg.state_manager
+
             questions = provider.generate_all_types()
+            questions = state_manager.filter_unasked_questions(self.area, questions)
             logger.debug(
                 f"[QuizDuelGame] dynamic questions generated: {len(questions)}"
             )
@@ -394,6 +397,9 @@ class QuizDuelGame:
                 msg = await self.thread.send(embed=embed, view=view)
                 view.message = msg
                 await view.wait()
+                question_id = question.get("id")
+                if question_id is not None:
+                    await state_manager.mark_question_as_asked(self.area, question_id)
                 winner_id = view.winner_id
                 if winner_id:
                     self.scores[winner_id] += 1

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -229,12 +229,6 @@ async def duel(
         )
         return
 
-    if modus == "box" and best_of is None:
-        await interaction.response.send_message(
-            "❌ Bitte gib die Rundenzahl an.", ephemeral=True
-        )
-        return
-
     champion_cog = interaction.client.get_cog("ChampionCog")
     if champion_cog is None:
         await interaction.response.send_message(
@@ -245,6 +239,12 @@ async def duel(
     if quiz_cog and interaction.user.id in quiz_cog.active_duels:
         await interaction.response.send_message(
             "❌ Du bist bereits in einem Duell.", ephemeral=True
+        )
+        return
+
+    if modus == "box" and best_of is None:
+        await interaction.response.send_message(
+            "❌ Bitte gib die Rundenzahl an.", ephemeral=True
         )
         return
     total = await champion_cog.data.get_total(str(interaction.user.id))


### PR DESCRIPTION
## Summary
- filter dynamic duel questions using the question state manager
- record asked dynamic questions
- ensure slash command checks active duel before round amount check
- verify dynamic duel questions are marked as asked

## Testing
- `python -m py_compile cogs/quiz/slash_commands.py cogs/quiz/duel.py tests/quiz/test_duel.py`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68457271a4d8832fa403f0f0567b6c72