### PR TITLE
Implement round validation for quiz duels

### DIFF
--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -247,6 +247,11 @@ async def duel(
             "❌ Bitte gib die Rundenzahl an.", ephemeral=True
         )
         return
+    if modus == "box" and best_of is not None and best_of % 2 == 0:
+        await interaction.response.send_message(
+            "❌ Bitte wähle eine ungerade Rundenzahl.", ephemeral=True
+        )
+        return
     total = await champion_cog.data.get_total(str(interaction.user.id))
     if total < punkte:
         await interaction.response.send_message(


### PR DESCRIPTION
## Summary
- prevent even round counts in `/quiz duel`
- test for rejecting even round counts

## Testing
- `black . --quiet`
- `python -m py_compile cogs/quiz/slash_commands.py tests/quiz/test_duel.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c327f488832f9e037bcc3b61a400