### PR TITLE
Add black formatting check to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,10 @@ jobs:
           pip install -r requirements.txt
           pip install pytest pytest-asyncio
           pip install flake8
+          pip install black
+      - name: Check formatting
+        run: |
+          black --check .
       - name: Run linter
         run: |
           flake8 .


### PR DESCRIPTION
## Summary
- install `black` in tests workflow
- run `black --check .` before linter step

## Testing
- `black .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c39ffcdc832f9b57961172dd954b