### PR TITLE
QuestionGenerator Fallback verbessert

### DIFF
--- a/cogs/quiz/question_generator.py
+++ b/cogs/quiz/question_generator.py
@@ -49,7 +49,11 @@ class QuestionGenerator:
                     continue
                 question = q
                 break
-            questions = [question] if question else []
+
+            if question:
+                questions = [question]
+            else:
+                questions = provider.generate_all_types()
             logger.debug(
                 f"[QuestionGenerator] Dynamische Frage für '{area}': {len(questions)}"
             )


### PR DESCRIPTION
## Zusammenfassung
- erweitere `QuestionGenerator.generate` um Fallback auf `generate_all_types`
- passe Tests an und prüfe neues Verhalten

## Testing
- `black . --quiet`
- `python -m py_compile cogs/quiz/question_generator.py tests/quiz/test_question_generator.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684726fd0430832f98256ce4ff4cf09d