### PR TITLE
Improve duel logging

### DIFF
--- a/cogs/quiz/duel.py
+++ b/cogs/quiz/duel.py
@@ -494,6 +494,15 @@ class QuizDuelGame:
             if inspect.isawaitable(question):
                 question = await question
             if not question:
+                state_manager = getattr(qg, "state_manager", None)
+                remaining = "?"
+                if state_manager is not None:
+                    asked = len(state_manager.get_asked_questions(self.area))
+                    total = len(qg.questions_by_area.get("de", {}).get(self.area, []))
+                    remaining = max(total - asked, 0)
+                logger.info(
+                    f"[QuizDuelGame] no question generated in '{self.area}' round={rnd} remaining={remaining}"
+                )
                 await self.thread.send("Keine Frage generiert. Duell abgebrochen.")
                 champion_cog = self.cog.bot.get_cog("ChampionCog")
                 if champion_cog:


### PR DESCRIPTION
## Summary
- log remaining questions when duel mode can't generate a question

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68472705b5f4832f9cf227e19c14b93d