### PR TITLE
Fix check_answer validation for empty input

### DIFF
--- a/cogs/quiz/utils.py
+++ b/cogs/quiz/utils.py
@@ -20,6 +20,12 @@ def check_answer(
     """
     normalized_user = normalize_text(user_answer)
 
+    if not normalized_user:
+        logger.debug(
+            f"[check_answer] empty normalized user answer from '{user_answer}'"
+        )
+        return False
+
     for correct in correct_answers:
         normalized_correct = normalize_text(correct)
 

--- a/tests/quiz/test_check_answer.py
+++ b/tests/quiz/test_check_answer.py
@@ -19,3 +19,11 @@ def test_fuzzy_match():
 
 def test_mismatch():
     assert check_answer("London", ["Paris"]) is False
+
+
+def test_empty_normalized_input():
+    assert check_answer("//", ["Paris"]) is False
+
+
+def test_whitespace_input():
+    assert check_answer("   ", ["Paris"]) is False


### PR DESCRIPTION
## Summary
- reject answers that normalize to an empty string
- add regression tests for invalid user input

## Testing
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684760dff8e0832f91ae1bb7aede518a