### PR TITLE
Implement selective message tracking

### DIFF
--- a/tests/quiz/test_message_tracker.py
+++ b/tests/quiz/test_message_tracker.py
@@ -76,6 +76,17 @@ def test_register_message_increments_and_triggers(monkeypatch, patch_logged_task
     assert len(triggered) == 1
 
 
+def test_register_message_ignores_unrelated_channels():
+    bot = DummyBot()
+    tracker = MessageTracker(bot, bot.quiz_cog.manager.ask_question)
+
+    msg = DummyMessage(999)
+    tracker.register_message(msg)
+
+    assert 999 not in tracker.message_counter
+    assert tracker.message_counter == {}
+
+
 @pytest.mark.asyncio
 async def test_initialize_counts_history(monkeypatch):
     quiz_embed_title = "Quiz f\u00fcr AREA1"


### PR DESCRIPTION
## Summary
- ignore messages from unrelated channels in quiz tracker
- clear old message counters when quiz config updates
- add test for ignoring unrelated channels

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849404db220832fa6613a17c79ed79c