### PR TITLE
Build and store WCR category lookups

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -49,7 +49,11 @@ class WCRCog(commands.Cog):
             self.unit_name_map[lang] = name_map
             self.id_name_map[lang] = id_map
             self.name_token_index[lang] = token_index
-        helpers.build_category_lookup(self.languages, self.pictures)
+
+        (
+            self.lang_category_lookup,
+            self.picture_category_lookup,
+        ) = helpers.build_category_lookup(self.languages, self.pictures)
 
         # Emojis liegen in bot.data["emojis"]
         self.emojis = bot.data["emojis"]

--- a/cogs/wcr/helpers.py
+++ b/cogs/wcr/helpers.py
@@ -6,20 +6,22 @@ from log_setup import get_logger
 logger = get_logger(__name__)
 
 
-def build_category_lookup(languages: dict, pictures: dict) -> None:
-    """Add lookup dictionaries for faster category access."""
-    for lang_data in languages.values():
+def build_category_lookup(languages: dict, pictures: dict) -> tuple[dict, dict]:
+    """Return lookup dictionaries for faster category access."""
+    lang_lookup: dict[str, dict[str, dict[int, dict]]] = {}
+    for lang, lang_data in languages.items():
         categories = lang_data.get("categories", {})
         lookup = {}
         for name, items in categories.items():
             lookup[name] = {item["id"]: item for item in items}
-        lang_data["category_lookup"] = lookup
+        lang_lookup[lang] = lookup
 
     pic_categories = pictures.get("categories", {})
-    pictures["category_lookup"] = {
+    pic_lookup = {
         name: {item["id"]: item for item in items}
         for name, items in pic_categories.items()
     }
+    return lang_lookup, pic_lookup
 
 
 def get_text_data(unit_id: int, lang: str, languages: dict) -> tuple[str, str, list]:

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -125,6 +125,17 @@ def test_name_map_contains_unit():
     cog.cog_unload()
 
 
+def test_category_lookups_created():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+
+    assert "factions" in cog.lang_category_lookup["de"]
+    assert "factions" in cog.picture_category_lookup
+    assert "category_lookup" not in bot.data["wcr"]["locals"]["de"]
+    assert "category_lookup" not in bot.data["wcr"]["pictures"]
+    cog.cog_unload()
+
+
 def test_token_index_contains_token():
     bot = DummyBot()
     cog = WCRCog(bot)


### PR DESCRIPTION
## Summary
- return new dicts from `build_category_lookup`
- keep language and picture lookups separately in `WCRCog`
- update WCR cog tests

## Testing
- `black . --quiet`
- `python -m py_compile cogs/wcr/helpers.py cogs/wcr/cog.py tests/wcr/test_wcr_cog.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849406dee50832f80720469d0fdfb6f