### PR TITLE
Fix WCR type 5 question selection

### DIFF
--- a/cogs/quiz/area_providers/wcr.py
+++ b/cogs/quiz/area_providers/wcr.py
@@ -182,11 +182,14 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         }
 
     def generate_type_5(self):
-        if len(self.units) < 2:
-            return None
-        u1, u2 = random.sample(self.units, 2)
         stat_keys = ["health", "damage", "attack_speed", "dps"]
         stat = random.choice(stat_keys)
+        units_with_stat = [
+            u for u in self.units if u.get("stats", {}).get(stat) is not None
+        ]
+        if len(units_with_stat) < 2:
+            return None
+        u1, u2 = random.sample(units_with_stat, 2)
         template = (
             self.locals.get(self.language, {})
             .get("question_templates", {})

--- a/tests/wcr/test_wcr_question_provider.py
+++ b/tests/wcr/test_wcr_question_provider.py
@@ -64,12 +64,26 @@ def test_generate_type_4(monkeypatch):
 
 def test_generate_type_5(monkeypatch):
     provider = create_provider()
-    units = provider.units
-    monkeypatch.setattr(random, "sample", lambda seq, k: [units[0], units[1]])
-    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "choice", lambda seq: "damage")
+    monkeypatch.setattr(random, "sample", lambda seq, k: seq[:k])
     q = provider.generate_type_5()
     assert q is not None
     assert "frage" in q and "antwort" in q and "id" in q
+
+
+def test_generate_type_5_requires_two_units(monkeypatch):
+    provider = create_provider()
+    units = provider.units
+    provider.units = [units[1], units[3]]
+
+    monkeypatch.setattr(random, "choice", lambda seq: "damage")
+
+    def fail(*args, **kwargs):
+        raise AssertionError("sample should not be called")
+
+    monkeypatch.setattr(random, "sample", fail)
+    q = provider.generate_type_5()
+    assert q is None
 
 
 def test_generate_all_types(monkeypatch):


### PR DESCRIPTION
## Summary
- make `generate_type_5` pick a stat first and sample only from units that contain that stat
- improve tests for deterministic type 5 questions and missing unit scenarios

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685321b25078832f855346df8d803837