### PR TITLE
Implement basic duel feature

### DIFF
--- a/cogs/wcr/slash_commands.py
+++ b/cogs/wcr/slash_commands.py
@@ -87,3 +87,29 @@ async def name(interaction: discord.Interaction, name: str, lang: str = "de"):
     logger.info(f"/wcr name by {interaction.user} name={name} lang={lang}")
     cog: WCRCog = interaction.client.get_cog("WCRCog")
     await cog.cmd_name(interaction, name, lang)
+
+
+@wcr_group.command(
+    name="duell",
+    description="Lässt zwei Minis virtuell gegeneinander antreten.",
+)
+@app_commands.describe(
+    mini_a="Erstes Mini (Name oder ID)",
+    level_a="Level des ersten Minis (1-31)",
+    mini_b="Zweites Mini (Name oder ID)",
+    level_b="Level des zweiten Minis (1-31)",
+    lang="Sprache",
+)
+async def duell(
+    interaction: discord.Interaction,
+    mini_a: str,
+    level_a: app_commands.Range[int, 1, 31],
+    mini_b: str,
+    level_b: app_commands.Range[int, 1, 31],
+    lang: str = "de",
+):
+    logger.info(
+        f"/wcr duell by {interaction.user} a={mini_a} la={level_a} b={mini_b} lb={level_b} lang={lang}"
+    )
+    cog: WCRCog = interaction.client.get_cog("WCRCog")
+    await cog.cmd_duel(interaction, mini_a, level_a, mini_b, level_b, lang)

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -275,3 +275,39 @@ async def test_trait_autocomplete_returns_sorted_matches():
     assert [c.name for c in choices] == ["Melee", "Elemental"]
     assert [c.value for c in choices] == ["3", "8"]
     cog.cog_unload()
+
+
+def test_scaled_stats_leveling():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+
+    units = bot.data["wcr"]["units"]
+    if isinstance(units, dict) and "units" in units:
+        units = units["units"]
+    unit = next(u for u in units if u["id"] == 26)
+
+    stats_lvl1 = cog._scaled_stats(unit, 1)
+    stats_lvl2 = cog._scaled_stats(unit, 2)
+    stats_lvl5 = cog._scaled_stats(unit, 5)
+
+    assert stats_lvl1["health"] == 1300
+    assert stats_lvl2["health"] == pytest.approx(1430)
+    assert stats_lvl5["health"] == pytest.approx(1820)
+    assert stats_lvl2["dps"] == pytest.approx(162, rel=0.01)
+    assert stats_lvl5["dps"] == pytest.approx(206, rel=0.01)
+    cog.cog_unload()
+
+
+def test_duel_result_flying_vs_melee():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+
+    units = bot.data["wcr"]["units"]
+    if isinstance(units, dict) and "units" in units:
+        units = units["units"]
+    unit_a = next(u for u in units if u["id"] == 26)
+    unit_b = next(u for u in units if u["id"] == 27)
+
+    result = cog.duel_result(unit_a, 1, unit_b, 1)
+    assert result[0] == "a"
+    cog.cog_unload()


### PR DESCRIPTION
## Summary
- add `/wcr duell` slash command
- compute scaled stats and duel result considering simple traits
- add tests for stat scaling and duel results

## Testing
- `flake8 .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855660d4bc4832facd5a2c5f1bdb945