### PR TITLE
Add public option to wcr commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Der Modus `dynamic` passt die Rundenzahl automatisch an und steht nur in Areas m
 | `/wcr filter`       | Minis über diverse Filter finden (Kosten, Fraktion, Traits ...)      |
 
 Autocomplete und Fuzzy-Matching erleichtern die Eingabe.
+Alle `/wcr`-Befehle besitzen zusätzlich den Parameter `public`, um die Antwort öffentlich anzuzeigen.
 
 ### `/ptcgp`
 

--- a/cogs/wcr/slash_commands.py
+++ b/cogs/wcr/slash_commands.py
@@ -59,6 +59,7 @@ async def _trait_ac(interaction, current):
     type="Typ des Minis",
     trait="Merkmal des Minis",
     lang="Sprache",
+    public="Antwort öffentlich anzeigen",
 )
 @app_commands.autocomplete(
     cost=_cost_ac, speed=_speed_ac, faction=_faction_ac, type=_type_ac, trait=_trait_ac
@@ -71,22 +72,27 @@ async def filter(
     type: str = None,
     trait: str = None,
     lang: str = "de",
+    public: bool = False,
 ):
     logger.info(
         f"/wcr filter by {interaction.user} cost={cost} speed={speed} faction={faction} type={type} trait={trait} lang={lang}"
     )
     cog: WCRCog = interaction.client.get_cog("WCRCog")
-    await cog.cmd_filter(interaction, cost, speed, faction, type, trait, lang)
+    await cog.cmd_filter(interaction, cost, speed, faction, type, trait, lang, public)
 
 
 @wcr_group.command(
     name="name", description="Zeigt Details zu einem Mini basierend auf dem Namen an."
 )
-@app_commands.describe(name="Name des Minis", lang="Sprache")
-async def name(interaction: discord.Interaction, name: str, lang: str = "de"):
+@app_commands.describe(
+    name="Name des Minis", lang="Sprache", public="Antwort öffentlich anzeigen"
+)
+async def name(
+    interaction: discord.Interaction, name: str, lang: str = "de", public: bool = False
+):
     logger.info(f"/wcr name by {interaction.user} name={name} lang={lang}")
     cog: WCRCog = interaction.client.get_cog("WCRCog")
-    await cog.cmd_name(interaction, name, lang)
+    await cog.cmd_name(interaction, name, lang, public)
 
 
 @wcr_group.command(
@@ -99,6 +105,7 @@ async def name(interaction: discord.Interaction, name: str, lang: str = "de"):
     mini_b="Zweites Mini (Name oder ID)",
     level_b="Level des zweiten Minis (1-31)",
     lang="Sprache",
+    public="Antwort \u00f6ffentlich anzeigen",
 )
 async def duell(
     interaction: discord.Interaction,
@@ -107,9 +114,10 @@ async def duell(
     mini_b: str,
     level_b: app_commands.Range[int, 1, 31],
     lang: str = "de",
+    public: bool = False,
 ):
     logger.info(
         f"/wcr duell by {interaction.user} a={mini_a} la={level_a} b={mini_b} lb={level_b} lang={lang}"
     )
     cog: WCRCog = interaction.client.get_cog("WCRCog")
-    await cog.cmd_duel(interaction, mini_a, level_a, mini_b, level_b, lang)
+    await cog.cmd_duel(interaction, mini_a, level_a, mini_b, level_b, lang, public)

--- a/cogs/wcr/views.py
+++ b/cogs/wcr/views.py
@@ -7,9 +7,10 @@ logger = get_logger(__name__)
 
 
 class MiniSelectView(discord.ui.View):
-    def __init__(self, options, cog, lang) -> None:
+    def __init__(self, options, cog, lang, public: bool = False) -> None:
         """View presenting a select menu of minis."""
         super().__init__(timeout=60)
+        self.public = public
         self.add_item(MiniSelect(options, cog, lang))
 
     async def on_timeout(self) -> None:
@@ -39,5 +40,7 @@ class MiniSelect(discord.ui.Select):
         logger.info(
             f"MiniSelect: {interaction.user} chose id={unit_id} lang={self.lang}"
         )
-        await interaction.response.defer(ephemeral=True)
-        await self.cog.send_mini_embed(interaction, unit_id, self.lang)
+        await interaction.response.defer(ephemeral=not self.view.public)
+        await self.cog.send_mini_embed(
+            interaction, unit_id, self.lang, public=self.view.public
+        )

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -311,3 +311,50 @@ def test_duel_result_flying_vs_melee():
     result = cog.duel_result(unit_a, 1, unit_b, 1)
     assert result[0] == "a"
     cog.cog_unload()
+
+
+@pytest.mark.asyncio
+async def test_cmd_filter_public():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_filter(inter, cost="6", lang="de", public=True)
+
+    msg = inter.response.messages[0]
+    assert msg["ephemeral"] is False
+    cog.cog_unload()
+
+
+@pytest.mark.asyncio
+async def test_cmd_name_public():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_name(inter, "Abscheulichkeit", lang="de", public=True)
+
+    msg = inter.followup.sent[0]
+    assert msg["ephemeral"] is False
+    cog.cog_unload()
+
+
+@pytest.mark.asyncio
+async def test_cmd_duel_public():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_duel(
+        inter,
+        "Gargoyle",
+        1,
+        "General Drakkisath",
+        1,
+        lang="de",
+        public=True,
+    )
+
+    msg = inter.followup.sent[0]
+    assert msg["ephemeral"] is False
+    cog.cog_unload()


### PR DESCRIPTION
## Summary
- allow to display `/wcr` results publicly via new `public` option
- pass visibility to views and cog logic
- document the new parameter in README
- test new `public` parameter behaviour

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556e2e0450832fb31a9872531abef9