### PR TITLE
Improve /wcr duel output

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Der Modus `dynamic` passt die Rundenzahl automatisch an und steht nur in Areas m
 |---------------------|---------------------------------------------------------------------|
 | `/wcr name`         | Details und Statistiken zu einer Einheit (mehrsprachig)             |
 | `/wcr filter`       | Minis über diverse Filter finden (Kosten, Fraktion, Traits ...)      |
+| `/wcr duell`        | Simuliert ein Duell zweier Minis und zeigt die Berechnung an |
 
 Autocomplete und Fuzzy-Matching erleichtern die Eingabe.
 Alle `/wcr`-Befehle besitzen zusätzlich den Parameter `public`, um die Antwort öffentlich anzuzeigen.

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -357,4 +357,7 @@ async def test_cmd_duel_public():
 
     msg = inter.followup.sent[0]
     assert msg["ephemeral"] is False
+    assert "Gargoyle" in msg["content"]
+    assert "General Drakkisath" in msg["content"]
+    assert "DPS" in msg["content"]
     cog.cog_unload()


### PR DESCRIPTION
## Summary
- enhance `/wcr duell` command with damage, DPS and level stats
- document new command in README
- assert duel output details in tests

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685572b1d070832fa563a1e95df0c028