### PR TITLE
Add WCR duel logging

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -318,6 +318,11 @@ class WCRCog(commands.Cog):
         public: bool = False,
     ):
         """Implementation for ``/wcr duell``."""
+        logger.info(
+            f"[WCR] /wcr duell von {interaction.user} - "
+            f"mini_a={mini_a}, level_a={level_a}, "
+            f"mini_b={mini_b}, level_b={level_b}, lang={lang}"
+        )
         await interaction.response.defer(ephemeral=not public)
 
         res_a = self.resolve_unit(mini_a, lang)


### PR DESCRIPTION
## Summary
- log `/wcr duell` usage with minis, levels and language

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855c9303e20832fa3156857997c4b4b