### PR TITLE
Handle zero DPS duels

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -342,6 +342,23 @@ class WCRCog(commands.Cog):
         dps_a = self._compute_dps(data_a, stats_a, data_b)
         dps_b = self._compute_dps(data_b, stats_b, data_a)
 
+        def _flight_issue(att: dict, def_: dict) -> bool:
+            ta = att.get("traits_ids", [])
+            td = def_.get("traits_ids", [])
+            if att.get("type_id") == 2:
+                return False
+            return 15 in td and 11 not in ta and 15 not in ta
+
+        issue_a = _flight_issue(data_a, data_b)
+        issue_b = _flight_issue(data_b, data_a)
+
+        if (issue_a or dps_a == 0) and (issue_b or dps_b == 0):
+            await interaction.followup.send(
+                "Keines der Minis kann den Gegner treffen.",
+                ephemeral=not public,
+            )
+            return
+
         winner_data = self.duel_result(data_a, level_a, data_b, level_b)
 
         is_spell_a = data_a.get("type_id") == 2
@@ -394,16 +411,6 @@ class WCRCog(commands.Cog):
                 f"Level {lvl}: Schaden {dmg_scaled:.0f}, "
                 f"DPS {dps_scaled:.0f}, HP {hp_scaled:.0f}"
             )
-
-        def _flight_issue(att: dict, def_: dict) -> bool:
-            ta = att.get("traits_ids", [])
-            td = def_.get("traits_ids", [])
-            if att.get("type_id") == 2:
-                return False
-            return 15 in td and 11 not in ta and 15 not in ta
-
-        issue_a = _flight_issue(data_a, data_b)
-        issue_b = _flight_issue(data_b, data_a)
 
         parts = [f"{header}\n"]
 

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -395,3 +395,24 @@ async def test_cmd_duel_public():
     assert "General Drakkisath" in msg["content"]
     assert "DPS" in msg["content"]
     cog.cog_unload()
+
+
+@pytest.mark.asyncio
+async def test_cmd_duel_no_damage_message():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_duel(
+        inter,
+        "Banshee",
+        1,
+        "Bergbewohner",
+        1,
+        lang="de",
+    )
+
+    msg = inter.followup.sent[0]
+    assert msg["content"] == "Keines der Minis kann den Gegner treffen."
+    assert msg["ephemeral"] is True
+    cog.cog_unload()


### PR DESCRIPTION
## Summary
- detect duel cases where both Minis can't damage each other
- respond with "Keines der Minis kann den Gegner treffen." in that case
- test new behaviour in WCR cog

## Testing
- `black .`
- `python -m py_compile cogs/wcr/cog.py tests/wcr/test_wcr_cog.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c93188e8832fa0a86ef521b5c0a2