### PR TITLE
Fix ephemeral myhistory response when empty

### DIFF
--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -151,7 +151,9 @@ async def myhistory(interaction: discord.Interaction):
     total = await cog.data.get_total(user_id_str)
 
     if not history_list:
-        await interaction.response.send_message("📭 Du hast noch keine Historie.")
+        await interaction.response.send_message(
+            "📭 Du hast noch keine Historie.", ephemeral=True
+        )
         return
 
     lines = []

--- a/tests/champion/test_myhistory_ephemeral_empty.py
+++ b/tests/champion/test_myhistory_ephemeral_empty.py
@@ -1,0 +1,62 @@
+import pytest
+
+from cogs.champion.slash_commands import myhistory
+
+
+class DummyBot:
+    def __init__(self):
+        self._cog = None
+
+    def get_cog(self, name):
+        return self._cog if name == "ChampionCog" else None
+
+
+class DummyCog:
+    def __init__(self):
+        self.data = type(
+            "Data", (), {"get_history": self.get_history, "get_total": self.get_total}
+        )()
+
+    async def get_history(self, user_id, limit=10):
+        return []
+
+    async def get_total(self, user_id):
+        return 0
+
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, msg, ephemeral=False):
+        self.messages.append((msg, ephemeral))
+
+
+class DummyMember:
+    def __init__(self, uid):
+        self.id = uid
+        self.mention = f"<@{uid}>"
+        self.display_name = f"User{uid}"
+
+
+class DummyInteraction:
+    def __init__(self, bot):
+        self.client = bot
+        self.user = DummyMember(999)
+        self.response = DummyResponse()
+        self.followup = DummyResponse()
+        self.guild = None
+
+
+@pytest.mark.asyncio
+async def test_myhistory_empty_is_ephemeral():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+
+    await myhistory.callback(inter)
+
+    assert inter.response.messages
+    _, ephemeral = inter.response.messages[0]
+    assert ephemeral is True


### PR DESCRIPTION
## Summary
- ensure `/champion myhistory` sends an ephemeral message when history is empty
- test ephemeral behaviour for empty history

## Testing
- `black . --quiet`
- `python -m py_compile cogs/champion/slash_commands.py tests/champion/test_myhistory_ephemeral_empty.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cdc1db40832fb2ae2a24df8d4411