### PR TITLE
Implement quiz area autocomplete

### DIFF
--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -48,6 +48,17 @@ def save_area_config(bot: commands.Bot):
         json.dump(out, f, indent=2, ensure_ascii=False)
 
 
+async def area_autocomplete(
+    interaction: discord.Interaction, current: str
+) -> list[app_commands.Choice[str]]:
+    """Autocomplete available quiz areas based on ``current`` text."""
+    bot = interaction.client
+    current_lower = current.lower()
+    matches = [name for name in bot.quiz_data.keys() if current_lower in name.lower()]
+    matches.sort()
+    return [app_commands.Choice(name=m, value=m) for m in matches[:25]]
+
+
 @quiz_group.command(
     name="time", description="Zeitfenster (in Minuten) für dieses Quiz setzen"
 )
@@ -127,6 +138,7 @@ async def threshold(
 @app_commands.describe(
     area_name="Name der Area (z. B. wcr, d4, ptcgp)", lang="de oder en"
 )
+@app_commands.autocomplete(area_name=area_autocomplete)
 @app_commands.default_permissions(manage_guild=True)
 async def enable(
     interaction: discord.Interaction, area_name: str, lang: Literal["de", "en"] = "de"

--- a/tests/quiz/test_area_autocomplete.py
+++ b/tests/quiz/test_area_autocomplete.py
@@ -1,0 +1,39 @@
+import pytest
+
+from cogs.quiz.quiz_config import QuizAreaConfig
+from cogs.quiz.slash_commands import area_autocomplete
+
+
+class DummyBot:
+    def __init__(self):
+        self.quiz_data = {}
+
+
+class DummyInteraction:
+    def __init__(self, bot):
+        self.client = bot
+
+
+@pytest.mark.asyncio
+async def test_area_autocomplete_returns_all():
+    bot = DummyBot()
+    bot.quiz_data = {"a": QuizAreaConfig(), "b": QuizAreaConfig()}
+    inter = DummyInteraction(bot)
+
+    choices = await area_autocomplete(inter, "")
+
+    assert [c.name for c in choices] == ["a", "b"]
+    assert [c.value for c in choices] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_area_autocomplete_filters_case_insensitive():
+    bot = DummyBot()
+    bot.quiz_data = {"AreaOne": QuizAreaConfig(), "Two": QuizAreaConfig()}
+    inter = DummyInteraction(bot)
+
+    choices = await area_autocomplete(inter, "area")
+
+    assert len(choices) == 1
+    assert choices[0].name == "AreaOne"
+    assert choices[0].value == "AreaOne"


### PR DESCRIPTION
## Summary
- implement `area_autocomplete` helper
- add autocomplete to `/quiz enable`
- test quiz area autocomplete functionality

## Testing
- `black . --quiet`
- `python -m py_compile cogs/quiz/slash_commands.py tests/quiz/test_area_autocomplete.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cfa0918c832f82260148328439a9