### PR TITLE
Add quiz stats feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Beim ersten Start werden persistente Daten unter `data/pers/` angelegt (Punkteda
 | `/quiz reset`         | Fragehistorie für diesen Channel löschen *(Mod)*                    |
 | `/quiz duel`          | Starte ein Quiz-Duell (Best‑of‑X oder dynamic, optionaler Timeout). Nach jeder Runde werden Lösung, Antworten und Reaktionszeiten angezeigt |
 | `/quiz duelstats`     | Eigene oder fremde Duell-Bilanz anzeigen |
+| `/quiz stats`         | Anzahl deiner (oder fremder) richtigen Antworten anzeigen |
 | `/quiz duelleaderboard` | Rangliste der meisten Duell-Siege |
 
 Der Modus `dynamic` passt die Rundenzahl automatisch an und steht nur in Areas mit dynamischen Fragen (momentan `wcr`) zur Verfügung.

--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -14,6 +14,7 @@ from .question_manager import QuestionManager
 from .question_restorer import QuestionRestorer
 from .question_state import QuestionInfo, QuestionStateManager
 from .scheduler import QuizScheduler
+from .stats import QuizStats
 
 logger = get_logger(__name__)
 
@@ -42,6 +43,7 @@ class QuizCog(commands.Cog):
         self.awaiting_activity: dict[int, tuple[str, float]] = {}
         self.schedulers: dict[str, QuizScheduler] = {}
         self.active_duels: set[int] = set()
+        self.stats = QuizStats("data/pers/quiz/stats.json")
 
         # Find existing QuestionStateManager or create a default one
         state = None

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -365,6 +365,26 @@ async def status(interaction: discord.Interaction):
         )
 
 
+@quiz_group.command(name="stats", description="Zeigt Anzahl richtiger Antworten")
+@app_commands.describe(user="Optionaler Nutzer, dessen Statistik gezeigt wird")
+async def stats(interaction: discord.Interaction, user: discord.Member | None = None):
+    quiz_cog: QuizCog | None = interaction.client.get_cog("QuizCog")
+    if quiz_cog is None:
+        await interaction.response.send_message(
+            "❌ Quiz-System nicht verfügbar.", ephemeral=True
+        )
+        return
+
+    target = user or interaction.user
+    count = quiz_cog.stats.get(target.id)
+
+    if target.id == interaction.user.id and user is None:
+        msg = f"📈 Du hast bisher {count} richtige Antworten gegeben."
+    else:
+        msg = f"📈 {target.display_name} hat bisher {count} richtige Antworten gegeben."
+    await interaction.response.send_message(msg, ephemeral=True)
+
+
 @quiz_group.command(name="duelstats", description="Zeigt deine Duell-Bilanz")
 @app_commands.describe(user="Optionaler Nutzer, dessen Statistik gezeigt wird")
 async def duelstats(

--- a/cogs/quiz/stats.py
+++ b/cogs/quiz/stats.py
@@ -1,0 +1,46 @@
+import json
+import os
+import asyncio
+
+from log_setup import get_logger
+
+logger = get_logger(__name__)
+
+
+class QuizStats:
+    """Persistiert die Anzahl richtiger Antworten pro Nutzer."""
+
+    def __init__(self, filepath: str) -> None:
+        self.filepath = filepath
+        self._lock = asyncio.Lock()
+        self.data = self._load()
+
+    def _load(self) -> dict:
+        if not os.path.exists(self.filepath):
+            logger.info(f"[QuizStats] Datei nicht gefunden: {self.filepath}")
+            return {}
+        try:
+            with open(self.filepath, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as e:  # pragma: no cover - log error
+            logger.error(f"[QuizStats] Fehler beim Laden: {e}", exc_info=True)
+            return {}
+
+    async def _save(self) -> None:
+        async with self._lock:
+            try:
+                os.makedirs(os.path.dirname(self.filepath), exist_ok=True)
+                with open(self.filepath, "w", encoding="utf-8") as f:
+                    json.dump(self.data, f, indent=4, ensure_ascii=False)
+            except Exception as e:  # pragma: no cover - log error
+                logger.error(f"[QuizStats] Fehler beim Speichern: {e}", exc_info=True)
+
+    async def increment(self, user_id: int, delta: int = 1) -> int:
+        uid = str(user_id)
+        self.data[uid] = self.data.get(uid, 0) + delta
+        await self._save()
+        logger.debug(f"[QuizStats] {uid} -> {self.data[uid]}")
+        return self.data[uid]
+
+    def get(self, user_id: int) -> int:
+        return self.data.get(str(user_id), 0)

--- a/cogs/quiz/views.py
+++ b/cogs/quiz/views.py
@@ -40,6 +40,8 @@ class AnswerModal(Modal, title="Antwort eingeben"):
                 logger.info(
                     f"[Champion] {user.display_name} erhält 1 Punkt für '{self.area}'."
                 )
+            if hasattr(self.cog, "stats"):
+                await self.cog.stats.increment(user_id)
 
             await interaction.response.send_message(
                 "🏆 Richtig! Du erhältst einen Punkt.", ephemeral=True

--- a/tests/quiz/test_quiz_stats.py
+++ b/tests/quiz/test_quiz_stats.py
@@ -1,0 +1,67 @@
+import pytest
+
+from cogs.quiz.stats import QuizStats
+from cogs.quiz.views import AnswerModal
+from collections import defaultdict
+
+
+class DummyUser:
+    def __init__(self, uid):
+        self.id = uid
+        self.display_name = f"User{uid}"
+
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, content, **kwargs):
+        self.messages.append((content, kwargs.get("ephemeral")))
+
+
+class DummyInteraction:
+    def __init__(self, user):
+        self.user = user
+        self.response = DummyResponse()
+        self.created_at = None
+
+
+class DummyBot:
+    def get_cog(self, name):
+        return None
+
+
+class DummyCog:
+    def __init__(self, stats):
+        self.stats = stats
+        self.bot = DummyBot()
+        self.answered_users = defaultdict(set)
+        self.current_questions = {}
+        self.closer = None
+
+
+@pytest.mark.asyncio
+async def test_stats_increment(tmp_path):
+    path = tmp_path / "stats.json"
+    stats = QuizStats(str(path))
+
+    assert stats.get(1) == 0
+    await stats.increment(1)
+    await stats.increment(1)
+    assert stats.get(1) == 2
+    assert path.exists()
+
+
+@pytest.mark.asyncio
+async def test_answer_modal_updates_stats(tmp_path):
+    path = tmp_path / "stats.json"
+    stats = QuizStats(str(path))
+    cog = DummyCog(stats)
+    modal = AnswerModal("area", ["yes"], cog)
+    modal.answer._value = "yes"
+    inter = DummyInteraction(DummyUser(1))
+
+    await modal.on_submit(inter)
+
+    assert stats.get(1) == 1
+    assert inter.response.messages[0][0]


### PR DESCRIPTION
## Summary
- track correct answers in `data/pers/quiz/stats.json`
- update stats when a user answers correctly
- provide `/quiz stats` slash command
- document new command
- add tests for stat tracking and AnswerModal integration

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cfe19574832f9b9a0cd281d3086d