### PR TITLE
Switch champion roles to use role IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Cogs** trennen Funktionsbereiche sauber: `quiz`, `champion`, `wcr`.
 - **Zentrale Daten** werden im `setup_hook` geladen (`bot.data`) und allen Cogs bereitgestellt.
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
-- **Champion-System** speichert Punkte in SQLite und vergibt Rollen gemäß `data/champion/roles.json`.
+- **Champion-System** speichert Punkte in SQLite und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
 - **WCR-Modul** verarbeitet die Daten unter `data/wcr/` und bietet Autocomplete sowie dynamische Fragen als Quiz-Provider.
 - Alle Slash-Commands werden **guild-basiert** registriert und nur für die Haupt-Guild synchronisiert.
 

--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -253,11 +253,12 @@ async def leaderboard(interaction: discord.Interaction):
                 member = None
 
         name = member.display_name if member else f"Unbekannt ({user_id_str})"
-        role = cog.get_current_role(total) or "Champion"
-        grouped.setdefault(role, []).append((rank, name, total))
+        role_obj = cog.get_current_role(total)
+        role_name = role_obj.name if role_obj else "Champion"
+        grouped.setdefault(role_name, []).append((rank, name, total))
         rank += 1
 
-    role_order = [r[0] for r in cog.roles] + ["Champion"]
+    role_order = [r.name for r in cog.roles] + ["Champion"]
 
     output = []
     for role_name in role_order:
@@ -288,10 +289,10 @@ async def roles(interaction: discord.Interaction):
     logger.info(f"/champion roles requested by {interaction.user}")
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     lines = []
-    for name, threshold in cog.roles:
-        lines.append(f"{name}: ab {threshold} Punkte")
+    for role in cog.roles:
+        lines.append(f"{role.name}: ab {role.threshold} Punkte")
     lines.append(
-        "Champion: unter {0} Punkte".format(cog.roles[-1][1] if cog.roles else 0)
+        "Champion: unter {0} Punkte".format(cog.roles[-1].threshold if cog.roles else 0)
     )
     await interaction.response.send_message("\n".join(lines))
 

--- a/data/champion/roles.json
+++ b/data/champion/roles.json
@@ -1,21 +1,26 @@
 [
     {
+      "id": 1313206585186848860,
       "name": "Ultimate Champion",
       "threshold": 750
     },
     {
+      "id": 1313206531684302900,
       "name": "Epic Champion",
       "threshold": 500
     },
     {
+      "id": 1313206485685370910,
       "name": "Renowned Champion",
       "threshold": 300
     },
     {
+      "id": 1288423705231495202,
       "name": "Seasoned Champion",
       "threshold": 150
     },
     {
+      "id": 1288423580043837503,
       "name": "Emerging Champion",
       "threshold": 50
     }


### PR DESCRIPTION
## Summary
- add `id` field to champion role config
- refactor `ChampionCog` to use dataclass with role IDs
- adjust slash commands to work with the new dataclass
- update tests for role IDs
- document updated roles config in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855cbfb2b58832f9ba6ac08cae2f4cf