### PR TITLE
Refactor WCR duel logic into calculator class

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -8,6 +8,7 @@ import difflib
 from log_setup import get_logger
 from . import helpers
 from .views import MiniSelectView
+from .duel import DuelCalculator
 
 logger = get_logger(__name__)
 
@@ -339,13 +340,15 @@ class WCRCog(commands.Cog):
         name_a = helpers.get_text_data(id_a, lang_a, self.languages)[0]
         name_b = helpers.get_text_data(id_b, lang_b, self.languages)[0]
 
+        calculator = DuelCalculator()
+
         base_a = data_a.get("stats", {})
         base_b = data_b.get("stats", {})
-        stats_a = self._scaled_stats(data_a, level_a)
-        stats_b = self._scaled_stats(data_b, level_b)
+        stats_a = calculator.scaled_stats(data_a, level_a)
+        stats_b = calculator.scaled_stats(data_b, level_b)
 
-        dps_a = self._compute_dps(data_a, stats_a, data_b)
-        dps_b = self._compute_dps(data_b, stats_b, data_a)
+        dps_a = calculator.compute_dps(data_a, stats_a, data_b)
+        dps_b = calculator.compute_dps(data_b, stats_b, data_a)
 
         def _flight_issue(att: dict, def_: dict) -> bool:
             ta = att.get("traits_ids", [])
@@ -364,7 +367,7 @@ class WCRCog(commands.Cog):
             )
             return
 
-        winner_data = self.duel_result(data_a, level_a, data_b, level_b)
+        winner_data = calculator.duel_result(data_a, level_a, data_b, level_b)
 
         is_spell_a = data_a.get("type_id") == 2
         is_spell_b = data_b.get("type_id") == 2
@@ -814,134 +817,6 @@ class WCRCog(commands.Cog):
             await interaction.followup.send(
                 "Ein Fehler ist aufgetreten.", ephemeral=not public
             )
-
-    # ─── Duel Feature ------------------------------------------------------------
-    def _scale_stat(self, base: float | int, level: int) -> float:
-        """Return ``base`` scaled by +10% per level above 1."""
-        if level < 1:
-            level = 1
-        return base * (1 + 0.1 * (level - 1))
-
-    def _scaled_stats(self, unit_data: dict, level: int) -> dict:
-        """Return a copy of ``unit_data['stats']`` scaled for ``level``."""
-        stats = unit_data.get("stats", {})
-        result = {}
-        dmg_key = (
-            "damage"
-            if "damage" in stats
-            else "area_damage" if "area_damage" in stats else None
-        )
-        if dmg_key:
-            result[dmg_key] = self._scale_stat(stats[dmg_key], level)
-        if "health" in stats:
-            result["health"] = self._scale_stat(stats["health"], level)
-        attack_speed = stats.get("attack_speed")
-        if attack_speed is not None:
-            result["attack_speed"] = attack_speed
-        if dmg_key and attack_speed:
-            result["dps"] = result[dmg_key] / attack_speed
-        return result
-
-    def _spell_total_damage(self, unit: dict, stats: dict) -> float:
-        """Return estimated total damage a spell deals."""
-        base_stats = unit.get("stats", {})
-        damage = stats.get("damage", stats.get("area_damage", 0))
-        if "dps" in stats:
-            duration = base_stats.get("duration", 1)
-            damage = max(damage, stats["dps"] * duration)
-        return damage
-
-    def _compute_dps(
-        self,
-        attacker: dict,
-        attacker_stats: dict,
-        defender: dict,
-    ) -> float:
-        """Calculate DPS attacker does to defender considering traits."""
-        traits_a = attacker.get("traits_ids", [])
-        traits_d = defender.get("traits_ids", [])
-
-        # Check if attacker can hit flying target
-        if (
-            attacker.get("type_id") != 2
-            and 15 in traits_d
-            and 11 not in traits_a
-            and 15 not in traits_a
-        ):
-            return 0.0
-
-        dmg_key = (
-            "damage"
-            if "damage" in attacker_stats
-            else "area_damage" if "area_damage" in attacker_stats else None
-        )
-        if dmg_key is None:
-            return 0.0
-
-        damage = attacker_stats[dmg_key]
-        if 8 in traits_a and 20 in traits_d:  # elemental vs resistant
-            damage *= 0.5
-        elif 8 not in traits_a and 13 in traits_d:  # physical vs armored
-            damage *= 0.5
-
-        attack_speed = attacker_stats.get("attack_speed")
-        if attack_speed:
-            return damage / attack_speed
-
-        if attacker.get("type_id") == 2:
-            dps = attacker_stats.get("dps")
-            if dps is not None:
-                return dps
-            return damage
-
-        # Fallback to provided dps if available
-        return attacker_stats.get("dps", 0.0)
-
-    def duel_result(
-        self,
-        unit_a: dict,
-        level_a: int,
-        unit_b: dict,
-        level_b: int,
-    ) -> tuple[str, float] | None:
-        """Return (winner_name, time) or None for tie/impossible."""
-        stats_a = self._scaled_stats(unit_a, level_a)
-        stats_b = self._scaled_stats(unit_b, level_b)
-
-        is_spell_a = unit_a.get("type_id") == 2
-        is_spell_b = unit_b.get("type_id") == 2
-
-        dps_a = self._compute_dps(unit_a, stats_a, unit_b)
-        dps_b = self._compute_dps(unit_b, stats_b, unit_a)
-
-        if is_spell_a and is_spell_b:
-            if dps_a == dps_b:
-                return None
-            return ("a", 0.0) if dps_a > dps_b else ("b", 0.0)
-
-        if is_spell_a:
-            total_damage = self._spell_total_damage(unit_a, stats_a)
-            if total_damage >= stats_b.get("health", 0):
-                return "a", 0.0
-            return None
-
-        if is_spell_b:
-            total_damage = self._spell_total_damage(unit_b, stats_b)
-            if total_damage >= stats_a.get("health", 0):
-                return "b", 0.0
-            return None
-
-        health_a = stats_a.get("health", 0)
-        health_b = stats_b.get("health", 0)
-
-        time_a = health_b / dps_a if dps_a > 0 else float("inf")
-        time_b = health_a / dps_b if dps_b > 0 else float("inf")
-
-        if time_a == time_b:
-            return None
-        if time_a < time_b:
-            return "a", time_a
-        return "b", time_b
 
     def cog_unload(self):
         """Nothing to clean up when unloading the cog."""

--- a/cogs/wcr/duel.py
+++ b/cogs/wcr/duel.py
@@ -1,0 +1,130 @@
+from log_setup import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class DuelCalculator:
+    """Hilfsfunktionen für Mini-Duelle."""
+
+    def scale_stat(self, base: float | int, level: int) -> float:
+        """Return ``base`` scaled by +10% per level above 1."""
+        if level < 1:
+            level = 1
+        return base * (1 + 0.1 * (level - 1))
+
+    def scaled_stats(self, unit_data: dict, level: int) -> dict:
+        """Return a copy of ``unit_data['stats']`` scaled for ``level``."""
+        stats = unit_data.get("stats", {})
+        result = {}
+        dmg_key = (
+            "damage"
+            if "damage" in stats
+            else "area_damage" if "area_damage" in stats else None
+        )
+        if dmg_key:
+            result[dmg_key] = self.scale_stat(stats[dmg_key], level)
+        if "health" in stats:
+            result["health"] = self.scale_stat(stats["health"], level)
+        attack_speed = stats.get("attack_speed")
+        if attack_speed is not None:
+            result["attack_speed"] = attack_speed
+        if dmg_key and attack_speed:
+            result["dps"] = result[dmg_key] / attack_speed
+        return result
+
+    def spell_total_damage(self, unit: dict, stats: dict) -> float:
+        """Return estimated total damage a spell deals."""
+        base_stats = unit.get("stats", {})
+        damage = stats.get("damage", stats.get("area_damage", 0))
+        if "dps" in stats:
+            duration = base_stats.get("duration", 1)
+            damage = max(damage, stats["dps"] * duration)
+        return damage
+
+    def compute_dps(
+        self, attacker: dict, attacker_stats: dict, defender: dict
+    ) -> float:
+        """Calculate DPS attacker does to defender considering traits."""
+        traits_a = attacker.get("traits_ids", [])
+        traits_d = defender.get("traits_ids", [])
+
+        if (
+            attacker.get("type_id") != 2
+            and 15 in traits_d
+            and 11 not in traits_a
+            and 15 not in traits_a
+        ):
+            return 0.0
+
+        dmg_key = (
+            "damage"
+            if "damage" in attacker_stats
+            else "area_damage" if "area_damage" in attacker_stats else None
+        )
+        if dmg_key is None:
+            return 0.0
+
+        damage = attacker_stats[dmg_key]
+        if 8 in traits_a and 20 in traits_d:
+            damage *= 0.5
+        elif 8 not in traits_a and 13 in traits_d:
+            damage *= 0.5
+
+        attack_speed = attacker_stats.get("attack_speed")
+        if attack_speed:
+            return damage / attack_speed
+
+        if attacker.get("type_id") == 2:
+            dps = attacker_stats.get("dps")
+            if dps is not None:
+                return dps
+            return damage
+
+        return attacker_stats.get("dps", 0.0)
+
+    def duel_result(
+        self,
+        unit_a: dict,
+        level_a: int,
+        unit_b: dict,
+        level_b: int,
+    ) -> tuple[str, float] | None:
+        """Return (winner_name, time) or None for tie/impossible."""
+        stats_a = self.scaled_stats(unit_a, level_a)
+        stats_b = self.scaled_stats(unit_b, level_b)
+
+        is_spell_a = unit_a.get("type_id") == 2
+        is_spell_b = unit_b.get("type_id") == 2
+
+        dps_a = self.compute_dps(unit_a, stats_a, unit_b)
+        dps_b = self.compute_dps(unit_b, stats_b, unit_a)
+
+        if is_spell_a and is_spell_b:
+            if dps_a == dps_b:
+                return None
+            return ("a", 0.0) if dps_a > dps_b else ("b", 0.0)
+
+        if is_spell_a:
+            total_damage = self.spell_total_damage(unit_a, stats_a)
+            if total_damage >= stats_b.get("health", 0):
+                return "a", 0.0
+            return None
+
+        if is_spell_b:
+            total_damage = self.spell_total_damage(unit_b, stats_b)
+            if total_damage >= stats_a.get("health", 0):
+                return "b", 0.0
+            return None
+
+        health_a = stats_a.get("health", 0)
+        health_b = stats_b.get("health", 0)
+
+        time_a = health_b / dps_a if dps_a > 0 else float("inf")
+        time_b = health_a / dps_b if dps_b > 0 else float("inf")
+
+        if time_a == time_b:
+            return None
+        if time_a < time_b:
+            return "a", time_a
+        return "b", time_b

--- a/tests/wcr/test_duel_calculator.py
+++ b/tests/wcr/test_duel_calculator.py
@@ -1,0 +1,9 @@
+import pytest
+from cogs.wcr.duel import DuelCalculator
+
+
+def test_scale_stat():
+    calc = DuelCalculator()
+    assert calc.scale_stat(100, 1) == 100
+    assert calc.scale_stat(100, 2) == pytest.approx(110)
+    assert calc.scale_stat(100, 5) == pytest.approx(140)

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -5,6 +5,7 @@ import discord
 
 from cogs.wcr.cog import WCRCog
 from cogs.wcr.views import MiniSelectView
+from cogs.wcr.duel import DuelCalculator
 
 
 class DummyBot:
@@ -280,15 +281,16 @@ async def test_trait_autocomplete_returns_sorted_matches():
 def test_scaled_stats_leveling():
     bot = DummyBot()
     cog = WCRCog(bot)
+    calculator = DuelCalculator()
 
     units = bot.data["wcr"]["units"]
     if isinstance(units, dict) and "units" in units:
         units = units["units"]
     unit = next(u for u in units if u["id"] == 26)
 
-    stats_lvl1 = cog._scaled_stats(unit, 1)
-    stats_lvl2 = cog._scaled_stats(unit, 2)
-    stats_lvl5 = cog._scaled_stats(unit, 5)
+    stats_lvl1 = calculator.scaled_stats(unit, 1)
+    stats_lvl2 = calculator.scaled_stats(unit, 2)
+    stats_lvl5 = calculator.scaled_stats(unit, 5)
 
     assert stats_lvl1["health"] == 1300
     assert stats_lvl2["health"] == pytest.approx(1430)
@@ -305,10 +307,11 @@ def test_duel_result_flying_vs_melee():
     units = bot.data["wcr"]["units"]
     if isinstance(units, dict) and "units" in units:
         units = units["units"]
+    calculator = DuelCalculator()
     unit_a = next(u for u in units if u["id"] == 26)
     unit_b = next(u for u in units if u["id"] == 27)
 
-    result = cog.duel_result(unit_a, 1, unit_b, 1)
+    result = calculator.duel_result(unit_a, 1, unit_b, 1)
     assert result[0] == "a"
     cog.cog_unload()
 
@@ -321,11 +324,12 @@ def test_compute_dps_spell_hits_flying():
     if isinstance(units, dict) and "units" in units:
         units = units["units"]
 
+    calculator = DuelCalculator()
     spell = next(u for u in units if u["id"] == 10)
     flying = next(u for u in units if u["id"] == 6)
 
-    stats_spell = cog._scaled_stats(spell, 1)
-    dps = cog._compute_dps(spell, stats_spell, flying)
+    stats_spell = calculator.scaled_stats(spell, 1)
+    dps = calculator.compute_dps(spell, stats_spell, flying)
 
     assert dps > 0
     cog.cog_unload()
@@ -339,10 +343,11 @@ def test_duel_result_spell_vs_mini():
     if isinstance(units, dict) and "units" in units:
         units = units["units"]
 
+    calculator = DuelCalculator()
     spell = next(u for u in units if u["id"] == 10)
     mini = next(u for u in units if u["id"] == 6)
 
-    result = cog.duel_result(spell, 31, mini, 1)
+    result = calculator.duel_result(spell, 31, mini, 1)
     assert result == ("a", 0.0)
     cog.cog_unload()
 


### PR DESCRIPTION
## Summary
- move duel related methods into `DuelCalculator` class
- use `DuelCalculator` in `WCRCog.cmd_duel`
- adapt tests to new interface and add new unit tests

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855d12e6214832fae734967e723940d