### PR TITLE
Add duel calculator tie tests

### DIFF
--- a/tests/wcr/test_duel_calculator.py
+++ b/tests/wcr/test_duel_calculator.py
@@ -7,3 +7,29 @@ def test_scale_stat():
     assert calc.scale_stat(100, 1) == 100
     assert calc.scale_stat(100, 2) == pytest.approx(110)
     assert calc.scale_stat(100, 5) == pytest.approx(140)
+
+
+def test_spell_total_damage():
+    calc = DuelCalculator()
+    units = __import__("json").load(open("data/wcr/units.json", encoding="utf-8"))
+    units = units["units"] if isinstance(units, dict) and "units" in units else units
+    blizzard = next(u for u in units if u["id"] == 7)
+
+    stats_lvl1 = calc.scaled_stats(blizzard, 1)
+    stats_lvl2 = calc.scaled_stats(blizzard, 2)
+
+    dmg1 = calc.spell_total_damage(blizzard, stats_lvl1)
+    dmg2 = calc.spell_total_damage(blizzard, stats_lvl2)
+
+    assert dmg1 == pytest.approx(500)
+    assert dmg2 == pytest.approx(550)
+
+
+def test_duel_result_equal_damage_spells():
+    calc = DuelCalculator()
+    units = __import__("json").load(open("data/wcr/units.json", encoding="utf-8"))
+    units = units["units"] if isinstance(units, dict) and "units" in units else units
+    spell_a = next(u for u in units if u["id"] == 10)
+    spell_b = next(u for u in units if u["id"] == 36)
+
+    assert calc.duel_result(spell_a, 1, spell_b, 1) is None

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -352,6 +352,39 @@ def test_duel_result_spell_vs_mini():
     cog.cog_unload()
 
 
+def test_duel_result_equal_damage_spells():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+
+    units = bot.data["wcr"]["units"]
+    if isinstance(units, dict) and "units" in units:
+        units = units["units"]
+
+    calculator = DuelCalculator()
+    spell_a = next(u for u in units if u["id"] == 10)  # Chain Lightning
+    spell_b = next(u for u in units if u["id"] == 36)  # Holy Nova
+
+    result = calculator.duel_result(spell_a, 1, spell_b, 1)
+    assert result is None
+    cog.cog_unload()
+
+
+def test_duel_result_identical_minis():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+
+    units = bot.data["wcr"]["units"]
+    if isinstance(units, dict) and "units" in units:
+        units = units["units"]
+
+    calculator = DuelCalculator()
+    mini = next(u for u in units if u["id"] == 1)  # Abscheulichkeit
+
+    result = calculator.duel_result(mini, 1, mini, 1)
+    assert result is None
+    cog.cog_unload()
+
+
 @pytest.mark.asyncio
 async def test_cmd_filter_public():
     bot = DummyBot()
@@ -420,4 +453,47 @@ async def test_cmd_duel_no_damage_message():
     msg = inter.followup.sent[0]
     assert msg["content"] == "Keines der Minis kann den Gegner treffen."
     assert msg["ephemeral"] is True
+    cog.cog_unload()
+
+
+@pytest.mark.asyncio
+async def test_cmd_duel_identical_minis_tie():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_duel(
+        inter,
+        "Abscheulichkeit",
+        1,
+        "Abscheulichkeit",
+        1,
+        lang="de",
+    )
+
+    msg = inter.followup.sent[0]
+    assert msg["content"] == "Unentschieden oder kein Schaden."
+    assert msg["ephemeral"] is True
+    cog.cog_unload()
+
+
+@pytest.mark.asyncio
+async def test_cmd_duel_unknown_mini():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_duel(
+        inter,
+        "Unbekanntes Mini",
+        1,
+        "Abscheulichkeit",
+        1,
+        lang="de",
+        public=True,
+    )
+
+    msg = inter.followup.sent[0]
+    assert msg["content"] == "Eines der Minis wurde nicht gefunden."
+    assert msg["ephemeral"] is False
     cog.cog_unload()


### PR DESCRIPTION
## Summary
- expand duel calculator tests for spell damage totals and equal-damage spells
- cover ties, equal spells and unknown minis in WCRCog

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d3795b64832f868838debe14bad4