### PR TITLE
Manage quiz tasks with TaskGroup

### DIFF
--- a/cogs/quiz/scheduler.py
+++ b/cogs/quiz/scheduler.py
@@ -2,7 +2,7 @@ import random
 import asyncio
 import datetime
 
-from log_setup import get_logger, create_logged_task
+from log_setup import get_logger
 
 
 class QuizScheduler:
@@ -23,7 +23,7 @@ class QuizScheduler:
         self.logger = get_logger(__name__, area=area)
         self.post_time = post_time
         self.window_end = window_end
-        self.task = create_logged_task(self.run(), self.logger)
+        self.task: asyncio.Task | None = None
 
     async def run(self) -> None:
         """Background task loop scheduling questions in random intervals."""

--- a/cogs/quiz/slash_commands.py
+++ b/cogs/quiz/slash_commands.py
@@ -170,6 +170,7 @@ async def enable(
             prepare_question_callback=quiz_cog.manager.prepare_question,
             close_question_callback=quiz_cog.closer.close_question,
         )
+        scheduler.task = quiz_cog._track_task(scheduler.run())
         quiz_cog.schedulers[area] = scheduler
 
     save_area_config(interaction.client)


### PR DESCRIPTION
## Summary
- manage quiz background tasks via `asyncio.TaskGroup`
- launch schedulers using the new task group
- cancel all quiz tasks by closing the task group
- adjust related unit tests for the task group

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d30b0d14832f89e451f082d79dd7