### PR TITLE
Add startup role sync for ChampionCog

### DIFF
--- a/tests/champion/test_sync_on_init.py
+++ b/tests/champion/test_sync_on_init.py
@@ -1,0 +1,50 @@
+import asyncio
+import pytest
+
+from cogs.champion.cog import ChampionCog
+from cogs.champion.data import ChampionData
+import cogs.champion.cog as champion_cog_mod
+
+
+class DummyBot:
+    def __init__(self):
+        self.data = {"champion": {"roles": []}}
+        self.main_guild = None
+        self.guilds = []
+
+
+@pytest.mark.asyncio
+async def test_sync_called_on_init(monkeypatch, tmp_path):
+    data = ChampionData(str(tmp_path / "points.db"))
+    await data.add_delta("1", 5, "init")
+    await data.add_delta("2", 3, "init")
+
+    monkeypatch.setattr(champion_cog_mod, "ChampionData", lambda path: data)
+
+    calls = []
+
+    async def fake_apply(self, uid, score):
+        calls.append((uid, score))
+
+    tasks: list[asyncio.Task] = []
+
+    def schedule_task(coro, logger=None):
+        task = asyncio.create_task(coro)
+        tasks.append(task)
+        return task
+
+    monkeypatch.setattr(champion_cog_mod, "create_logged_task", schedule_task)
+    monkeypatch.setattr(
+        champion_cog_mod.ChampionCog, "_apply_champion_role", fake_apply
+    )
+
+    bot = DummyBot()
+    cog = ChampionCog(bot)
+
+    await asyncio.gather(*tasks)
+
+    assert set(calls) == {("1", 5), ("2", 3)}
+
+    cog.cog_unload()
+    await data.close()
+    await asyncio.gather(*tasks)


### PR DESCRIPTION
## Summary
- sync champion roles for all stored users when the cog starts
- launch the sync task in `ChampionCog.__init__`
- ensure tasks are cancelled properly
- test that role sync runs on cog setup

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d4bf2000832f92187e89717f68f2