### PR TITLE
Implement unit name autocomplete

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -132,6 +132,31 @@ class WCRCog(commands.Cog):
         """Autocomplete unit traits."""
         return self._autocomplete(self.trait_choices, current)
 
+    async def unit_name_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> list[discord.app_commands.Choice]:
+        """Autocomplete Minis über alle unterstützten Sprachen."""
+        normalized = " ".join(helpers.normalize_name(current))
+        matched_ids: set[int] = set()
+        for mapping in self.unit_name_map.values():
+            for name, uid in mapping.items():
+                if not normalized or normalized in name:
+                    matched_ids.add(uid)
+
+        results: list[discord.app_commands.Choice] = []
+        for lang in self.languages:
+            for uid in matched_ids:
+                unit_name = helpers.get_text_data(uid, lang, self.languages)[0]
+                results.append(
+                    discord.app_commands.Choice(
+                        name=f"{unit_name} [{lang}]", value=str(uid)
+                    )
+                )
+                if len(results) >= 25:
+                    return results[:25]
+
+        return results[:25]
+
     # ─── Ausgelagerte Slash-Logik ────────────────────────────────────────
     async def cmd_filter(
         self,

--- a/cogs/wcr/slash_commands.py
+++ b/cogs/wcr/slash_commands.py
@@ -49,6 +49,13 @@ async def _trait_ac(interaction, current):
     return await cog.trait_autocomplete(interaction, current)
 
 
+async def _unit_name_ac(interaction, current):
+    """Delegate unit name autocomplete to the cog."""
+    logger.debug(f"_unit_name_ac invoked by {interaction.user} current={current}")
+    cog: WCRCog = interaction.client.get_cog("WCRCog")
+    return await cog.unit_name_autocomplete(interaction, current)
+
+
 @wcr_group.command(
     name="filter", description="Filtert Minis basierend auf verschiedenen Kriterien."
 )
@@ -107,6 +114,7 @@ async def name(
     lang="Sprache",
     public="Antwort \u00f6ffentlich anzeigen",
 )
+@app_commands.autocomplete(mini_a=_unit_name_ac, mini_b=_unit_name_ac)
 async def duell(
     interaction: discord.Interaction,
     mini_a: str,

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -278,6 +278,26 @@ async def test_trait_autocomplete_returns_sorted_matches():
     cog.cog_unload()
 
 
+@pytest.mark.asyncio
+async def test_unit_name_autocomplete_multilang():
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    choices = await cog.unit_name_autocomplete(inter, "abo")
+
+    names = {c.name for c in choices}
+    assert "Abscheulichkeit [de]" in names
+    assert "Abomination [en]" in names
+    values = {
+        c.value
+        for c in choices
+        if c.name in {"Abscheulichkeit [de]", "Abomination [en]"}
+    }
+    assert values == {"1"}
+    cog.cog_unload()
+
+
 def test_scaled_stats_leveling():
     bot = DummyBot()
     cog = WCRCog(bot)


### PR DESCRIPTION
## Summary
- add autocomplete for minis across languages
- expose autocomplete via slash command wrappers
- integrate autocomplete in duel command
- test cross-language unit name autocomplete

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855de8a0ef4832f9e1582ed5b965b0b