### PR TITLE
ChampionCog worker queue

### DIFF
--- a/tests/champion/test_sync_on_init.py
+++ b/tests/champion/test_sync_on_init.py
@@ -41,10 +41,10 @@ async def test_sync_called_on_init(monkeypatch, tmp_path):
     bot = DummyBot()
     cog = ChampionCog(bot)
 
-    await asyncio.gather(*tasks)
+    await tasks[0]
 
     assert set(calls) == {("1", 5), ("2", 3)}
 
     cog.cog_unload()
     await data.close()
-    await asyncio.gather(*tasks)
+    await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
## Summary
- create an update queue and worker task for ChampionCog
- adjust `update_user_score` to queue updates
- start/stop the worker properly
- update champion cog tests for new queue logic

## Testing
- `black . --quiet`
- `python -m compileall -q .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855deba9660832fb23b8acabc23764a