### PR TITLE
Make duel command levels optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Der Modus `dynamic` passt die Rundenzahl automatisch an und steht nur in Areas m
 |---------------------|---------------------------------------------------------------------|
 | `/wcr name`         | Details und Statistiken zu einer Einheit (mehrsprachig)             |
 | `/wcr filter`       | Minis über diverse Filter finden (Kosten, Fraktion, Traits ...)      |
-| `/wcr duell`        | Simuliert ein Duell zweier Minis und zeigt die Berechnung an |
+| `/wcr duell`        | Simuliert ein Duell zweier Minis (Level optional) und zeigt die Berechnung an |
+
+Wird kein Level angegeben, verwendet der Bot die Basiswerte (Level 1).
 
 Autocomplete und Fuzzy-Matching erleichtern die Eingabe.
 Alle `/wcr`-Befehle besitzen zusätzlich den Parameter `public`, um die Antwort öffentlich anzuzeigen.

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -312,9 +312,9 @@ class WCRCog(commands.Cog):
         self,
         interaction: discord.Interaction,
         mini_a: str,
-        level_a: int,
         mini_b: str,
-        level_b: int,
+        level_a: int = 1,
+        level_b: int = 1,
         lang: str = "de",
         public: bool = False,
     ):

--- a/cogs/wcr/slash_commands.py
+++ b/cogs/wcr/slash_commands.py
@@ -101,18 +101,18 @@ async def name(
 )
 @app_commands.describe(
     mini_a="Erstes Mini (Name oder ID)",
-    level_a="Level des ersten Minis (1-31)",
+    level_a="Level des ersten Minis (1-31, Standard 1)",
     mini_b="Zweites Mini (Name oder ID)",
-    level_b="Level des zweiten Minis (1-31)",
+    level_b="Level des zweiten Minis (1-31, Standard 1)",
     lang="Sprache",
     public="Antwort \u00f6ffentlich anzeigen",
 )
 async def duell(
     interaction: discord.Interaction,
     mini_a: str,
-    level_a: app_commands.Range[int, 1, 31],
     mini_b: str,
-    level_b: app_commands.Range[int, 1, 31],
+    level_a: app_commands.Range[int, 1, 31] = 1,
+    level_b: app_commands.Range[int, 1, 31] = 1,
     lang: str = "de",
     public: bool = False,
 ):
@@ -120,4 +120,4 @@ async def duell(
         f"/wcr duell by {interaction.user} a={mini_a} la={level_a} b={mini_b} lb={level_b} lang={lang}"
     )
     cog: WCRCog = interaction.client.get_cog("WCRCog")
-    await cog.cmd_duel(interaction, mini_a, level_a, mini_b, level_b, lang, public)
+    await cog.cmd_duel(interaction, mini_a, mini_b, level_a, level_b, lang, public)

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -420,8 +420,8 @@ async def test_cmd_duel_public():
     await cog.cmd_duel(
         inter,
         "Gargoyle",
-        1,
         "General Drakkisath",
+        1,
         1,
         lang="de",
         public=True,
@@ -444,8 +444,8 @@ async def test_cmd_duel_no_damage_message():
     await cog.cmd_duel(
         inter,
         "Banshee",
-        1,
         "Bergbewohner",
+        1,
         1,
         lang="de",
     )
@@ -465,8 +465,8 @@ async def test_cmd_duel_identical_minis_tie():
     await cog.cmd_duel(
         inter,
         "Abscheulichkeit",
-        1,
         "Abscheulichkeit",
+        1,
         1,
         lang="de",
     )
@@ -486,8 +486,8 @@ async def test_cmd_duel_unknown_mini():
     await cog.cmd_duel(
         inter,
         "Unbekanntes Mini",
-        1,
         "Abscheulichkeit",
+        1,
         1,
         lang="de",
         public=True,


### PR DESCRIPTION
## Summary
- make `/wcr duell` level parameters optional with default level 1
- adjust duel command implementation and tests
- document optional level parameters in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855df9b5710832f9ca24f40313ef72b