### PR TITLE
Fix remaining tests to call cog_unload

### DIFF
--- a/tests/champion/test_syncroles.py
+++ b/tests/champion/test_syncroles.py
@@ -70,4 +70,5 @@ async def test_syncroles_processes_all_users(monkeypatch, tmp_path, patch_logged
     msg, ephemeral = inter.followup.sent[0]
     assert ephemeral is True
     cog.cog_unload()
+    await cog.wait_closed()
     await cog.data.close()

--- a/tests/champion/test_syncroles.py
+++ b/tests/champion/test_syncroles.py
@@ -69,4 +69,5 @@ async def test_syncroles_processes_all_users(monkeypatch, tmp_path, patch_logged
     assert inter.followup.sent
     msg, ephemeral = inter.followup.sent[0]
     assert ephemeral is True
+    cog.cog_unload()
     await cog.data.close()

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -106,3 +106,4 @@ async def test_enable_starts_and_disable_stops(monkeypatch, patch_logged_task, b
 
     assert "area1" not in cog.schedulers
     assert task.cancelled
+    cog.cog_unload()

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -107,3 +107,4 @@ async def test_enable_starts_and_disable_stops(monkeypatch, patch_logged_task, b
     assert "area1" not in cog.schedulers
     assert task.cancelled
     cog.cog_unload()
+    await cog.wait_closed()

--- a/tests/quiz/test_scheduler_persistence.py
+++ b/tests/quiz/test_scheduler_persistence.py
@@ -95,3 +95,5 @@ async def test_scheduler_resume(monkeypatch, patch_logged_task, tmp_path):
     sched = cog2.schedulers["area1"]
     assert sched.post_time == post_time
     assert sched.window_end == window_end
+    cog.cog_unload()
+    cog2.cog_unload()

--- a/tests/quiz/test_scheduler_persistence.py
+++ b/tests/quiz/test_scheduler_persistence.py
@@ -97,3 +97,5 @@ async def test_scheduler_resume(monkeypatch, patch_logged_task, tmp_path):
     assert sched.window_end == window_end
     cog.cog_unload()
     cog2.cog_unload()
+    await cog.wait_closed()
+    await cog2.wait_closed()

--- a/utils/managed_cog.py
+++ b/utils/managed_cog.py
@@ -22,6 +22,13 @@ class ManagedTaskCog(commands.Cog):
             task.add_done_callback(lambda t: self.tasks.discard(t))
         return task
 
+    async def wait_closed(self) -> None:
+        to_await = [
+            t for t in self.tasks if asyncio.isfuture(t) or asyncio.iscoroutine(t)
+        ]
+        if to_await:
+            await asyncio.gather(*to_await, return_exceptions=True)
+
     def cog_unload(self) -> None:
         for task in list(self.tasks):
             task.cancel()


### PR DESCRIPTION
## Summary
- call `cog.cog_unload()` in all tests that instantiate cogs directly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 tests/champion/test_syncroles.py tests/quiz/test_quiz_scheduler.py tests/quiz/test_scheduler_persistence.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856668da938832f943e1c3eac1408b7