### PR TITLE
Stop discord views in tests

### DIFF
--- a/tests/quiz/test_duel.py
+++ b/tests/quiz/test_duel.py
@@ -201,6 +201,7 @@ async def test_start_duel_success(monkeypatch):
     ]
     assert message.edited_view is None
     assert run_called
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -217,6 +218,7 @@ async def test_start_duel_no_champion_system():
     assert view.accepted is False
     assert message.edited_view is None
     assert interaction.followup.sent[0][0].startswith("Champion-System")
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -236,6 +238,7 @@ async def test_start_duel_insufficient_points_challenger():
     assert message.edited_view is None
     assert bot._champion.calls == []
     assert interaction.followup.sent[0][0].startswith("Der Herausforderer")
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -255,6 +258,7 @@ async def test_start_duel_insufficient_points_opponent():
     assert message.edited_view == "INIT"
     assert bot._champion.calls == []
     assert interaction.followup.sent[0][0].startswith("Du hast nicht genug")
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -285,6 +289,7 @@ async def test_start_duel_thread_fail(monkeypatch):
         (1, 20, "Quiz-Duell Rückgabe"),
         (2, 20, "Quiz-Duell Rückgabe"),
     ]
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -321,6 +326,7 @@ async def test_invite_timeout_notifies():
     assert message.edited_view is None
     assert message.edited_view is None
     assert channel.sent == ["<@1>, deine Duellanfrage ist abgelaufen."]
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -621,6 +627,7 @@ async def test_start_duel_blocks_active_players():
     assert view.accepted is False
     assert bot._champion.calls == []
     assert message.edited_view is None
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -663,6 +670,7 @@ async def test_start_duel_run_exception_clears_active(monkeypatch):
         (1, 20, "Quiz-Duell Rückgabe"),
         (2, 20, "Quiz-Duell Rückgabe"),
     ]
+    view.stop()
 
 
 class SlashResponse:

--- a/tests/quiz/test_duel_question_view.py
+++ b/tests/quiz/test_duel_question_view.py
@@ -63,6 +63,7 @@ async def test_finish_sets_winner_and_disables_buttons():
     lines = fields["Antworten"].split("\n")
     assert lines[0].endswith("(1.0s)")
     assert lines[1].endswith("(0.0s)")
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -84,6 +85,7 @@ async def test_modal_ignores_after_finish():
     assert inter.response.sent == [
         ("Die Runde ist bereits beendet.", {"ephemeral": True})
     ]
+    view.stop()
 
 
 @pytest.mark.asyncio
@@ -96,3 +98,4 @@ async def test_on_timeout_sets_footer():
     await view.on_timeout()
 
     assert view.message.edited["embed"].footer.text.startswith("⏰")
+    view.stop()

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -66,8 +66,10 @@ async def test_cmd_filter_no_emojis():
 
     assert inter.response.messages
     msg = inter.response.messages[0]
-    assert isinstance(msg["view"], MiniSelectView)
+    view: MiniSelectView = msg["view"]
+    assert isinstance(view, MiniSelectView)
     assert msg["ephemeral"] is True
+    view.stop()
     cog.cog_unload()
 
 
@@ -80,7 +82,7 @@ async def test_cmd_filter_generates_options():
     await cog.cmd_filter(inter, cost="6", lang="de")
 
     msg = inter.response.messages[0]
-    view = msg["view"]
+    view: MiniSelectView = msg["view"]
     options = view.children[0].options
 
     units = bot.data["wcr"]["units"]
@@ -95,6 +97,7 @@ async def test_cmd_filter_generates_options():
     expected = [names[u["id"]] for u in units if u["cost"] == 6]
 
     assert [o.label for o in options] == expected
+    view.stop()
     cog.cog_unload()
 
 
@@ -414,7 +417,9 @@ async def test_cmd_filter_public():
     await cog.cmd_filter(inter, cost="6", lang="de", public=True)
 
     msg = inter.response.messages[0]
+    view: MiniSelectView = msg["view"]
     assert msg["ephemeral"] is False
+    view.stop()
     cog.cog_unload()
 
 


### PR DESCRIPTION
## Summary
- prevent hanging tests by stopping `discord.ui.View` instances

## Testing
- `flake8 .`
- `pytest -q` *(fails: process blocked by environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_685679d774b4832fabfa62b0c5e3f54c