### PR TITLE
Fix test teardown to await tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ flake8       # Linting
 pytest -q    # Test Suite
 ```
 
-Neue Features benötigen passende Tests. Die Fixtures in `tests/conftest.py` stellen Umgebungsvariablen bereit und bieten `patch_logged_task`, um `create_logged_task` zu ersetzen.
+Neue Features benötigen passende Tests. Die Fixtures in `tests/conftest.py` stellen Umgebungsvariablen bereit und bieten `patch_logged_task`, das `create_logged_task` nun global ersetzt. Ebenfalls sorgt `auto_stop_views` dafür, dass in Tests erstellte `discord.ui.View`-Instanzen automatisch gestoppt werden.
 
 Pull Requests sind willkommen! Bitte halte dich an den bestehenden Codestyle (PEP8, formatiert mit *Black*) und prüfe vor dem Commit, dass `flake8` und `pytest` grün sind.
 

--- a/tests/champion/test_champion_cog.py
+++ b/tests/champion/test_champion_cog.py
@@ -98,6 +98,7 @@ async def test_update_user_score_saves_and_calls(
     assert called == [("123", 5)]
     cog.cog_unload()
     await asyncio.gather(*tasks, return_exceptions=True)
+    await cog.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -175,6 +176,7 @@ async def test_apply_role_removes_when_below_threshold(monkeypatch, patch_logged
     assert member.added == []
     cog.cog_unload()
     await cog.data.close()
+    await cog.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -221,5 +223,6 @@ async def test_worker_cancelled_on_unload(monkeypatch, patch_logged_task):
 
     cog.cog_unload()
     await asyncio.gather(*tasks, return_exceptions=True)
+    await cog.wait_closed()
 
     assert cog.worker_task.cancelled()

--- a/tests/champion/test_sync_on_init.py
+++ b/tests/champion/test_sync_on_init.py
@@ -49,3 +49,4 @@ async def test_sync_called_on_init(monkeypatch, tmp_path):
     cog.cog_unload()
     await data.close()
     await asyncio.gather(*tasks, return_exceptions=True)
+    await cog.wait_closed()

--- a/tests/quiz/test_quiz_scheduler.py
+++ b/tests/quiz/test_quiz_scheduler.py
@@ -50,6 +50,7 @@ async def test_scheduler_start_and_stop(monkeypatch, patch_logged_task, bot):
     assert not task.cancelled
 
     cog.cog_unload()
+    await cog.wait_closed()
     assert task.cancelled
 
 


### PR DESCRIPTION
## Summary
- extend `patch_logged_task` fixture to patch globally
- stop discord `View` objects automatically in tests
- await `cog.wait_closed()` in tests that spawn background tasks
- document new fixtures

## Testing
- `black .`
- `python -m py_compile tests/conftest.py tests/champion/test_champion_cog.py tests/champion/test_sync_on_init.py tests/quiz/test_quiz_scheduler.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568236c058832face5a7af145d764d