### PR TITLE
Add fixture to detect stray asyncio tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ flake8       # Linting
 pytest -q    # Test Suite
 ```
 
-Neue Features benötigen passende Tests. Die Fixtures in `tests/conftest.py` stellen Umgebungsvariablen bereit und bieten `patch_logged_task`, das `create_logged_task` nun global ersetzt. Ebenfalls sorgt `auto_stop_views` dafür, dass in Tests erstellte `discord.ui.View`-Instanzen automatisch gestoppt werden.
+Neue Features benötigen passende Tests. Die Fixtures in `tests/conftest.py` stellen Umgebungsvariablen bereit und bieten `patch_logged_task`, das `create_logged_task` nun global ersetzt. Ebenfalls sorgt `auto_stop_views` dafür, dass in Tests erstellte `discord.ui.View`-Instanzen automatisch gestoppt werden. Das neue Fixture `assert_no_tasks` prüft zudem, ob nach jedem Test noch asyncio-Tasks laufen und schlägt sonst fehl.
 
 Pull Requests sind willkommen! Bitte halte dich an den bestehenden Codestyle (PEP8, formatiert mit *Black*) und prüfe vor dem Commit, dass `flake8` und `pytest` grün sind.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 import pytest_asyncio
 import discord
+import asyncio
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:
@@ -63,6 +64,18 @@ def auto_stop_views(monkeypatch):
             view.stop()
         except Exception:
             pass
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def assert_no_tasks():
+    """Ensure that tests do not leave running tasks behind."""
+
+    yield
+
+    current = asyncio.current_task()
+    stray = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+
+    assert not stray, f"Stray tasks detected: {stray}"
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary
- test framework: add `assert_no_tasks` fixture
- document task-checking fixture in README

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568f5a480c832f8ee22aa789f114f4