### PR TITLE
Ensure Cogs and tasks close cleanly

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -195,6 +195,12 @@ class MyBot(commands.Bot):
         with open(emoji_file, "r", encoding="utf-8") as f:
             return json.load(f)
 
+    async def close(self) -> None:
+        """Entlade alle Cogs, bevor der Bot beendet wird."""
+        for cog_name in list(self.cogs.keys()):
+            await self.remove_cog(cog_name)
+        await super().close()
+
 
 if __name__ == "__main__":
     token = os.getenv("bot_key")

--- a/cogs/ptcgp/cog.py
+++ b/cogs/ptcgp/cog.py
@@ -1,15 +1,17 @@
 import asyncio
 from discord.ext import commands
 
-from log_setup import get_logger, create_logged_task
+from log_setup import get_logger
+from utils.managed_cog import ManagedTaskCog
 from .data import PTCGPData
 from .api import fetch_all_cards
 
 logger = get_logger(__name__)
 
 
-class PTCGPCog(commands.Cog):
+class PTCGPCog(ManagedTaskCog):
     def __init__(self, bot: commands.Bot) -> None:
+        super().__init__()
         self.bot = bot
         self.data = PTCGPData("data/pers/ptcgp/cards.db")
         self._lock = asyncio.Lock()
@@ -39,4 +41,4 @@ class PTCGPCog(commands.Cog):
         return await self.data.get_card(card_id)
 
     def cog_unload(self):
-        create_logged_task(self.data.close(), logger)
+        self.create_task(self.data.close())

--- a/tests/ptcgp/test_ptcgp_cog.py
+++ b/tests/ptcgp/test_ptcgp_cog.py
@@ -64,4 +64,5 @@ async def test_update_command(monkeypatch, tmp_path):
     counts = await cog.data.count_cards()
     assert counts == {"en": 1, "de": 1}
 
-    await cog.data.close()
+    cog.cog_unload()
+    await cog.wait_closed()


### PR DESCRIPTION
## Summary
- unload all cogs when shutting down `MyBot`
- manage PTCGPCog tasks via ManagedTaskCog
- track database close task on unload
- clean up PTCGPCog in tests

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569745160c832fabeca5065c3795d6