### PR TITLE
ChampionCog nutzt managed Task fürs DB-Schließen

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Zentrale Daten** werden im `setup_hook` geladen (`bot.data`) und allen Cogs bereitgestellt.
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
 - **Champion-System** speichert Punkte in SQLite und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
+- Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
 - **WCR-Modul** verarbeitet die Daten unter `data/wcr/` und bietet Autocomplete sowie dynamische Fragen als Quiz-Provider.
 - Alle Slash-Commands werden **guild-basiert** registriert und nur für die Haupt-Guild synchronisiert.
 

--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from discord.ext import commands
 from typing import Optional, List
 
-from log_setup import get_logger, create_logged_task
+from log_setup import get_logger
 from utils.managed_cog import ManagedTaskCog
 from .data import ChampionData
 
@@ -157,5 +157,7 @@ class ChampionCog(ManagedTaskCog):
             )
 
     def cog_unload(self):
+        """Cancel Tasks und schließe die Datenbankverbindung."""
         super().cog_unload()
-        create_logged_task(self.data.close(), logger)
+        # Datenbank sauber schließen, damit keine offenen Tasks bleiben
+        self.create_task(self.data.close())


### PR DESCRIPTION
## Summary
- schließe Datenbank im `ChampionCog` über `self.create_task`
- ergänze Doku zur sauberen DB-Trennung

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569ff7454c832f8be8b94f8489cb14