### PR TITLE
Fix localization typos

### DIFF
--- a/data/wcr/locals/de.json
+++ b/data/wcr/locals/de.json
@@ -1875,7 +1875,7 @@
         "health": "Health",
         "speed_id": "Speed",
         "damage": "Damage",
-        "area_damage": "AOE Damange",
+        "area_damage": "AOE Damage",
         "attack_speed": "ATK Speed",
         "dps": "DPS",
         "range": "Range",

--- a/data/wcr/locals/en.json
+++ b/data/wcr/locals/en.json
@@ -1665,7 +1665,7 @@
             },
             {
                 "id": 10,
-                "name": "Possesion"
+                "name": "Possession"
             },
             {
                 "id": 11,
@@ -1849,7 +1849,7 @@
         "health": "Health",
         "speed_id": "Speed",
         "damage": "Damage",
-        "area_damage": "AOE Damange",
+        "area_damage": "AOE Damage",
         "attack_speed": "ATK Speed",
         "dps": "DPS",
         "range": "Range",


### PR DESCRIPTION
## Summary
- correct AOE Damage spelling in localizations
- fix the Possession trait name

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bcb3a578832f8dca7b920da4d3ff