### PR TITLE
Load WCR quiz templates from new directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Pull Requests sind willkommen! Bitte halte dich an den bestehenden Codestyle (PE
 
 **Antwort:** Bearbeite die Dateien unter `data/quiz/questions_de.json` bzw. `questions_en.json`. Füge eigene Fragen mit eindeutiger ID hinzu und starte den Bot neu.
 
+**Frage:** *Wo passe ich Vorlagen für WCR-Fragen an?*
+
+**Antwort:** Die Texte für dynamische Fragen findest du in `data/quiz/templates/wcr.json`.
+
 ---
 
 ## Changelog

--- a/bot.py
+++ b/bot.py
@@ -131,6 +131,13 @@ class MyBot(commands.Bot):
             quiz_questions[lang] = load_json(f)
             quiz_languages.append(lang)
 
+        # Vorlagen für dynamische Fragen laden
+        quiz_templates = {}
+        templates_dir = quiz_dir / "templates"
+        if templates_dir.exists():
+            for f in templates_dir.glob("*.json"):
+                quiz_templates[f.stem] = load_json(f)
+
         # WCR-Daten zentral laden
         wcr_data = load_wcr_data()
 
@@ -143,6 +150,7 @@ class MyBot(commands.Bot):
             "quiz": {
                 "questions": quiz_questions,
                 "languages": quiz_languages,
+                "templates": quiz_templates,
             },
             "wcr": wcr_data,
             "champion": {

--- a/cogs/quiz/area_providers/wcr.py
+++ b/cogs/quiz/area_providers/wcr.py
@@ -18,12 +18,14 @@ class WCRQuestionProvider(DynamicQuestionProvider):
     ]
 
     def __init__(self, bot, language="de"):
+        """Initialize the provider and load data from ``bot.data``."""
         units_data = bot.data["wcr"].get("units", [])
         # ``units.json`` may wrap the list of units in a top level key
         if isinstance(units_data, dict) and "units" in units_data:
             units_data = units_data["units"]
         self.units = units_data
         self.locals = bot.data["wcr"]["locals"]
+        self.templates = bot.data.get("quiz", {}).get("templates", {}).get("wcr", {})
         self.language = language
 
     def get_unit_name(self, unit_id: int, lang: str) -> str:
@@ -77,11 +79,7 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         if not talents:
             return None
         pick = random.choice(talents)
-        template = (
-            self.locals.get(self.language, {})
-            .get("question_templates", {})
-            .get("type_1")
-        )
+        template = self.templates.get(self.language, {}).get("type_1")
         if not template:
             return None
         question_text = template.format(talent_name=pick["talent_name"])
@@ -109,11 +107,7 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         if not talents:
             return None
         pick = random.choice(talents)
-        template = (
-            self.locals.get(self.language, {})
-            .get("question_templates", {})
-            .get("type_2")
-        )
+        template = self.templates.get(self.language, {}).get("type_2")
         if not template:
             return None
         question_text = template.format(talent_description=pick["talent_description"])
@@ -133,11 +127,7 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         if not self.units:
             return None
         unit = random.choice(self.units)
-        template = (
-            self.locals.get(self.language, {})
-            .get("question_templates", {})
-            .get("type_3")
-        )
+        template = self.templates.get(self.language, {}).get("type_3")
         if not template:
             return None
         question_text = template.format(
@@ -161,11 +151,7 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         if not self.units:
             return None
         unit = random.choice(self.units)
-        template = (
-            self.locals.get(self.language, {})
-            .get("question_templates", {})
-            .get("type_4")
-        )
+        template = self.templates.get(self.language, {}).get("type_4")
         if not template:
             return None
         cost = unit.get("cost")
@@ -190,11 +176,7 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         if len(units_with_stat) < 2:
             return None
         u1, u2 = random.sample(units_with_stat, 2)
-        template = (
-            self.locals.get(self.language, {})
-            .get("question_templates", {})
-            .get("type_5")
-        )
+        template = self.templates.get(self.language, {}).get("type_5")
         if not template:
             return None
         v1 = u1.get("stats", {}).get(stat)

--- a/data/quiz/templates/wcr.json
+++ b/data/quiz/templates/wcr.json
@@ -1,0 +1,16 @@
+{
+  "de": {
+    "type_1": "Welches Mini kann das Talent '{talent_name}' erlernen?",
+    "type_2": "\"{talent_description}\" - Welches Talent ist gesucht?",
+    "type_3": "Zu welcher Fraktion gehört der Mini '{unit_name}'?",
+    "type_4": "Wie viel Gold kostet es, den Mini '{unit_name}' zu spielen?",
+    "type_5": "Welches Mini hat mehr {stat_label}, '{unit1}' oder '{unit2}'?"
+  },
+  "en": {
+    "type_1": "Which mini can learn the talent '{talent_name}'?",
+    "type_2": "\"{talent_description}\" - Which talent is being sought?",
+    "type_3": "Which faction does the mini '{unit_name}' belong to?",
+    "type_4": "How much gold does it cost to play the mini '{unit_name}'?",
+    "type_5": "Which mini has more {stat_label}, '{unit1}' or '{unit2}'?"
+  }
+}

--- a/tests/quiz/test_wcr_provider.py
+++ b/tests/quiz/test_wcr_provider.py
@@ -6,20 +6,21 @@ from cogs.quiz.utils import create_permutations_list
 
 
 class DummyBot:
-    def __init__(self, units, locals_):
-        self.data = {"wcr": {"units": units, "locals": locals_}}
+    def __init__(self, units, locals_, templates):
+        self.data = {
+            "wcr": {"units": units, "locals": locals_},
+            "quiz": {"templates": {"wcr": templates}},
+        }
 
 
 def test_generate_type_1(monkeypatch, patch_logged_task):
     patch_logged_task(log_setup)
     units = [{"id": 1}]
     locals_ = {
-        "de": {
-            "units": [{"id": 1, "name": "Einheit", "talents": [{"name": "Talent"}]}],
-            "question_templates": {"type_1": "Wer hat {talent_name}?"},
-        }
+        "de": {"units": [{"id": 1, "name": "Einheit", "talents": [{"name": "Talent"}]}]}
     }
-    bot = DummyBot(units, locals_)
+    templates = {"de": {"type_1": "Wer hat {talent_name}?"}}
+    bot = DummyBot(units, locals_, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -50,11 +51,11 @@ def test_generate_type_2(monkeypatch, patch_logged_task):
                     "name": "U2",
                     "talents": [{"name": "T2", "description": "desc"}],
                 },
-            ],
-            "question_templates": {"type_2": "{talent_description}?"},
+            ]
         }
     }
-    bot = DummyBot(units, locals_)
+    templates = {"de": {"type_2": "{talent_description}?"}}
+    bot = DummyBot(units, locals_, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -76,10 +77,10 @@ def test_generate_type_3(monkeypatch, patch_logged_task):
         "de": {
             "units": [{"id": 1, "name": "U1"}],
             "categories": {"factions": [{"id": 1, "name": "Faction"}]},
-            "question_templates": {"type_3": "Fraktion von {unit_name}?"},
         }
     }
-    bot = DummyBot(units, locals_)
+    templates = {"de": {"type_3": "Fraktion von {unit_name}?"}}
+    bot = DummyBot(units, locals_, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -99,10 +100,10 @@ def test_generate_type_4(monkeypatch, patch_logged_task):
     locals_ = {
         "de": {
             "units": [{"id": 1, "name": "U1"}],
-            "question_templates": {"type_4": "Kosten von {unit_name}?"},
         }
     }
-    bot = DummyBot(units, locals_)
+    templates = {"de": {"type_4": "Kosten von {unit_name}?"}}
+    bot = DummyBot(units, locals_, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -125,12 +126,10 @@ def test_generate_type_5(monkeypatch, patch_logged_task):
     locals_ = {
         "de": {
             "units": [{"id": 1, "name": "U1"}, {"id": 2, "name": "U2"}],
-            "question_templates": {
-                "type_5": "Wer hat mehr {stat_label}, {unit1} oder {unit2}?"
-            },
         }
     }
-    bot = DummyBot(units, locals_)
+    templates = {"de": {"type_5": "Wer hat mehr {stat_label}, {unit1} oder {unit2}?"}}
+    bot = DummyBot(units, locals_, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: "health")
     monkeypatch.setattr(random, "sample", lambda seq, k: seq[:k])

--- a/tests/wcr/test_wcr_question_provider.py
+++ b/tests/wcr/test_wcr_question_provider.py
@@ -1,4 +1,5 @@
 import random
+import json
 
 
 from cogs.quiz.area_providers.wcr import WCRQuestionProvider
@@ -13,7 +14,12 @@ def create_provider():
     bot = DummyBot()
     from cogs.wcr.utils import load_wcr_data
 
-    bot.data = {"wcr": load_wcr_data()}
+    from pathlib import Path
+
+    with open(Path("data/quiz/templates/wcr.json"), "r", encoding="utf-8") as f:
+        templates = json.load(f)
+
+    bot.data = {"wcr": load_wcr_data(), "quiz": {"templates": {"wcr": templates}}}
     return WCRQuestionProvider(bot, language="de")
 
 


### PR DESCRIPTION
## Summary
- add templates folder with `wcr.json`
- load dynamic question templates in `bot.py`
- adjust `WCRQuestionProvider` to read templates from `bot.data['quiz']['templates']['wcr']`
- update FAQ in README
- modify unit tests for new template source

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857163b6108832fa4d05f21f1c044ea