### PR TITLE
Use dedicated WCR datasets

### DIFF
--- a/cogs/quiz/area_providers/wcr.py
+++ b/cogs/quiz/area_providers/wcr.py
@@ -4,6 +4,7 @@ from log_setup import get_logger
 import hashlib
 from ..utils import create_permutations_list
 from .base import DynamicQuestionProvider
+from ...wcr import helpers
 
 logger = get_logger(__name__)
 
@@ -25,8 +26,12 @@ class WCRQuestionProvider(DynamicQuestionProvider):
             units_data = units_data["units"]
         self.units = units_data
         self.locals = bot.data["wcr"]["locals"]
+        self.categories = bot.data["wcr"].get("categories", {})
         self.templates = bot.data.get("quiz", {}).get("templates", {}).get("wcr", {})
         self.language = language
+        self.lang_category_lookup, _ = helpers.build_category_lookup(
+            self.categories, {}
+        )
 
     def get_unit_name(self, unit_id: int, lang: str) -> str:
         try:
@@ -134,10 +139,9 @@ class WCRQuestionProvider(DynamicQuestionProvider):
             unit_name=self.get_unit_name(unit["id"], self.language)
         )
         faction_id = unit.get("faction_id")
-        factions = (
-            self.locals.get(self.language, {}).get("categories", {}).get("factions", [])
+        faction = helpers.get_category_name(
+            "factions", faction_id, self.language, self.lang_category_lookup
         )
-        faction = next((f["name"] for f in factions if f["id"] == faction_id), None)
         if not faction:
             return None
         return {

--- a/cogs/wcr/utils.py
+++ b/cogs/wcr/utils.py
@@ -63,6 +63,19 @@ def load_pictures():
         return {}
 
 
+def load_categories():
+    """Lädt die Kategorien aus ``categories.json``."""
+    path = BASE_PATH / "categories.json"
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            categories = json.load(f)
+        logger.info("[WCRUtils] Kategorien erfolgreich geladen.")
+        return categories
+    except Exception as e:
+        logger.error(f"[WCRUtils] Fehler beim Laden der Kategorien: {e}")
+        return {}
+
+
 def load_stat_labels():
     """Lädt die Stat-Labels aus ``stat_labels.json``."""
     path = BASE_PATH / "stat_labels.json"
@@ -82,5 +95,6 @@ def load_wcr_data():
         "units": load_units(),
         "locals": load_languages(),
         "pictures": load_pictures(),
+        "categories": load_categories(),
         "stat_labels": load_stat_labels(),
     }

--- a/tests/quiz/test_wcr_provider.py
+++ b/tests/quiz/test_wcr_provider.py
@@ -6,9 +6,9 @@ from cogs.quiz.utils import create_permutations_list
 
 
 class DummyBot:
-    def __init__(self, units, locals_, templates):
+    def __init__(self, units, locals_, categories, templates):
         self.data = {
-            "wcr": {"units": units, "locals": locals_},
+            "wcr": {"units": units, "locals": locals_, "categories": categories},
             "quiz": {"templates": {"wcr": templates}},
         }
 
@@ -20,7 +20,7 @@ def test_generate_type_1(monkeypatch, patch_logged_task):
         "de": {"units": [{"id": 1, "name": "Einheit", "talents": [{"name": "Talent"}]}]}
     }
     templates = {"de": {"type_1": "Wer hat {talent_name}?"}}
-    bot = DummyBot(units, locals_, templates)
+    bot = DummyBot(units, locals_, {}, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -55,7 +55,7 @@ def test_generate_type_2(monkeypatch, patch_logged_task):
         }
     }
     templates = {"de": {"type_2": "{talent_description}?"}}
-    bot = DummyBot(units, locals_, templates)
+    bot = DummyBot(units, locals_, {}, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -73,14 +73,10 @@ def test_generate_type_2(monkeypatch, patch_logged_task):
 def test_generate_type_3(monkeypatch, patch_logged_task):
     patch_logged_task(log_setup)
     units = [{"id": 1, "faction_id": 1}]
-    locals_ = {
-        "de": {
-            "units": [{"id": 1, "name": "U1"}],
-            "categories": {"factions": [{"id": 1, "name": "Faction"}]},
-        }
-    }
+    locals_ = {"de": {"units": [{"id": 1, "name": "U1"}]}}
+    categories = {"factions": [{"id": 1, "names": {"de": "Faction"}}]}
     templates = {"de": {"type_3": "Fraktion von {unit_name}?"}}
-    bot = DummyBot(units, locals_, templates)
+    bot = DummyBot(units, locals_, categories, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -103,7 +99,7 @@ def test_generate_type_4(monkeypatch, patch_logged_task):
         }
     }
     templates = {"de": {"type_4": "Kosten von {unit_name}?"}}
-    bot = DummyBot(units, locals_, templates)
+    bot = DummyBot(units, locals_, {}, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -129,7 +125,7 @@ def test_generate_type_5(monkeypatch, patch_logged_task):
         }
     }
     templates = {"de": {"type_5": "Wer hat mehr {stat_label}, {unit1} oder {unit2}?"}}
-    bot = DummyBot(units, locals_, templates)
+    bot = DummyBot(units, locals_, {}, templates)
     provider = WCRQuestionProvider(bot, language="de")
     monkeypatch.setattr(random, "choice", lambda seq: "health")
     monkeypatch.setattr(random, "sample", lambda seq, k: seq[:k])

--- a/tests/wcr/test_wcr_helpers.py
+++ b/tests/wcr/test_wcr_helpers.py
@@ -13,6 +13,19 @@ def languages():
 
 
 @pytest.fixture(scope="module")
+def categories():
+    from cogs.wcr.utils import load_categories
+
+    return load_categories()
+
+
+@pytest.fixture(scope="module")
+def lang_lookup(categories, pictures):
+    lookup, _ = helpers.build_category_lookup(categories, pictures)
+    return lookup
+
+
+@pytest.fixture(scope="module")
 def pictures():
     return json.load(open("data/wcr/pictures.json", "r", encoding="utf-8"))
 
@@ -41,13 +54,13 @@ def test_get_pose_url_unknown(pictures):
     assert helpers.get_pose_url(9999, pictures) == ""
 
 
-def test_get_category_name_known(languages):
-    name = helpers.get_category_name("factions", 1, "de", languages)
+def test_get_category_name_known(lang_lookup):
+    name = helpers.get_category_name("factions", 1, "de", lang_lookup)
     assert name == "Untote"
 
 
-def test_get_category_name_unknown(languages):
-    name = helpers.get_category_name("factions", 9999, "de", languages)
+def test_get_category_name_unknown(lang_lookup):
+    name = helpers.get_category_name("factions", 9999, "de", lang_lookup)
     assert name == "Unbekannt"
 
 
@@ -68,23 +81,23 @@ def test_get_faction_icon_unknown(pictures):
     assert helpers.get_faction_icon(9999, pictures) == ""
 
 
-def test_find_category_id_in_current_lang(languages):
-    cid = helpers.find_category_id("Untote", "factions", "de", languages)
+def test_find_category_id_in_current_lang(lang_lookup):
+    cid = helpers.find_category_id("Untote", "factions", "de", lang_lookup)
     assert cid == 1
 
 
-def test_find_category_id_in_other_lang(languages):
-    cid = helpers.find_category_id("Alliance", "factions", "de", languages)
+def test_find_category_id_in_other_lang(lang_lookup):
+    cid = helpers.find_category_id("Alliance", "factions", "de", lang_lookup)
     assert cid == 3
 
 
-def test_find_category_id_case_insensitive(languages):
-    cid = helpers.find_category_id("untote", "factions", "de", languages)
+def test_find_category_id_case_insensitive(lang_lookup):
+    cid = helpers.find_category_id("untote", "factions", "de", lang_lookup)
     assert cid == 1
 
 
-def test_find_category_id_unknown(languages):
-    cid = helpers.find_category_id("Foobar", "factions", "de", languages)
+def test_find_category_id_unknown(lang_lookup):
+    cid = helpers.find_category_id("Foobar", "factions", "de", lang_lookup)
     assert cid is None
 
 


### PR DESCRIPTION
## Summary
- add loader for `categories.json`
- extend WCR data to include categories
- build category lookups from new dataset
- update helpers and cogs to use category lookups
- adjust question provider
- adapt tests

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571949bd8c832f96ad91a7fe835b6e