### PR TITLE
Implement updated WCR data access

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
 - **Champion-System** speichert Punkte in SQLite und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
-- **WCR-Modul** verarbeitet die Daten unter `data/wcr/` und bietet Autocomplete sowie dynamische Fragen als Quiz-Provider.
+- **WCR-Modul** verarbeitet die Daten unter `data/wcr/` und bietet Autocomplete sowie dynamische Fragen als Quiz-Provider. Einheiten, Kategorien und Stat-Bezeichnungen werden dabei aus `units.json`, `categories.json` und `stat_labels.json` geladen.
 - Alle Slash-Commands werden **guild-basiert** registriert und nur für die Haupt-Guild synchronisiert.
 
 Persistente Daten liegen in `data/pers/` und sollten nicht ins Repository aufgenommen werden.

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -185,7 +185,6 @@ class WCRCog(commands.Cog):
             )
             return
 
-        texts = self.languages[lang]
         filtered_units = self.units
 
         # Kosten filtern
@@ -291,8 +290,7 @@ class WCRCog(commands.Cog):
         options = []
         for unit in filtered_units:
             unit_id = unit["id"]
-            unit_text = next((u for u in texts["units"] if u["id"] == unit_id), {})
-            unit_name = unit_text.get("name", "Unbekannt")
+            unit_name = helpers.get_text_data(unit_id, lang, self.languages)[0]
             emoji_syntax = self.emojis.get(
                 helpers.get_faction_icon(unit["faction_id"], self.pictures), {}
             ).get("syntax")
@@ -528,8 +526,6 @@ class WCRCog(commands.Cog):
         if lang not in self.languages:
             return None
 
-        texts = self.languages[lang]
-
         try:
             unit_id = int(name_or_id)
             unit_data = next(
@@ -537,11 +533,10 @@ class WCRCog(commands.Cog):
             )
             if not unit_data:
                 return None
-            matching_unit_text = next(
-                (u for u in texts["units"] if u["id"] == unit_id), None
-            )
-            if not matching_unit_text:
+            name, _, _ = helpers.get_text_data(unit_id, lang, self.languages)
+            if name == "Unbekannt":
                 return None
+            texts = self.languages[lang]
         except ValueError:
             normalized = " ".join(helpers.normalize_name(name_or_id))
             unit_id, lang = self._find_unit_id_by_name(normalized, lang)


### PR DESCRIPTION
## Summary
- refactor WCR cog to rely on helper functions for text lookups
- load unit names when filtering using helper methods
- document WCR data files in the architecture section of the README

## Testing
- `black .`
- `python -m py_compile cogs/wcr/cog.py cogs/wcr/helpers.py cogs/wcr/utils.py bot.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571b8f9cbc832fb68cf8bea130078b