### PR TITLE
Update WCR category handling

### DIFF
--- a/cogs/quiz/area_providers/wcr.py
+++ b/cogs/quiz/area_providers/wcr.py
@@ -29,9 +29,7 @@ class WCRQuestionProvider(DynamicQuestionProvider):
         self.categories = bot.data["wcr"].get("categories", {})
         self.templates = bot.data.get("quiz", {}).get("templates", {}).get("wcr", {})
         self.language = language
-        self.lang_category_lookup, _ = helpers.build_category_lookup(
-            self.categories, {}
-        )
+        self.lang_category_lookup = helpers.build_category_lookup(self.categories)
 
     def get_unit_name(self, unit_id: int, lang: str) -> str:
         try:

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -53,10 +53,7 @@ class WCRCog(commands.Cog):
             self.id_name_map[lang] = id_map
             self.name_token_index[lang] = token_index
 
-        (
-            self.lang_category_lookup,
-            self.picture_category_lookup,
-        ) = helpers.build_category_lookup(self.categories, self.pictures)
+        self.lang_category_lookup = helpers.build_category_lookup(self.categories)
 
         # Emojis liegen in bot.data["emojis"]
         self.emojis = bot.data["emojis"]
@@ -292,7 +289,8 @@ class WCRCog(commands.Cog):
             unit_id = unit["id"]
             unit_name = helpers.get_text_data(unit_id, lang, self.languages)[0]
             emoji_syntax = self.emojis.get(
-                helpers.get_faction_icon(unit["faction_id"], self.pictures), {}
+                helpers.get_faction_icon(unit["faction_id"], self.lang_category_lookup),
+                {},
             ).get("syntax")
             if emoji_syntax:
                 option = discord.SelectOption(
@@ -742,7 +740,7 @@ class WCRCog(commands.Cog):
 
         stat_labels = self.stat_labels.get(lang, {})
         faction_data = helpers.get_faction_data(
-            unit_data.get("faction_id"), self.pictures
+            unit_data.get("faction_id"), self.lang_category_lookup
         )
         embed_color = int(faction_data.get("color", "#3498db").strip("#"), 16)
         faction_emoji = self.emojis.get(faction_data.get("icon", ""), {}).get(

--- a/data/wcr/pictures.json
+++ b/data/wcr/pictures.json
@@ -291,39 +291,5 @@
       "id": 72,
       "pose": "https://warcraftrumble.gg/_ipx/_/rawimages/FaerieDragon_Statue.webp"
     }
-  ],
-  "categories": {
-    "factions": [
-      {
-        "id": 1,
-        "icon": "wcr_undead",
-        "color": "#6D4DBB"
-      },
-      {
-        "id": 2,
-        "icon": "wcr_beast",
-        "color": "#B08F58"
-      },
-      {
-        "id": 3,
-        "icon": "wcr_alliance",
-        "color": "#3A5FD0"
-      },
-      {
-        "id": 4,
-        "icon": "wcr_horde",
-        "color": "#BE4532"
-      },
-      {
-        "id": 5,
-        "icon": "wcr_blackrock",
-        "color": "#486166"
-      },
-      {
-        "id": 6,
-        "icon": "wcr_cenarion",
-        "color": "#359078"
-      }
-    ]
-  }
+  ]
 }

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -119,7 +119,6 @@ def test_category_lookups_created():
     cog = WCRCog(bot)
 
     assert "factions" in cog.lang_category_lookup["de"]
-    assert "factions" in cog.picture_category_lookup
     assert "category_lookup" not in bot.data["wcr"]["locals"]["de"]
     assert "category_lookup" not in bot.data["wcr"]["pictures"]
     cog.cog_unload()

--- a/tests/wcr/test_wcr_helpers.py
+++ b/tests/wcr/test_wcr_helpers.py
@@ -20,9 +20,9 @@ def categories():
 
 
 @pytest.fixture(scope="module")
-def lang_lookup(categories, pictures):
-    lookup, _ = helpers.build_category_lookup(categories, pictures)
-    return lookup
+def lang_lookup(categories):
+    """Erzeuge die Kategorie-Lookup-Tabelle für die Tests."""
+    return helpers.build_category_lookup(categories)
 
 
 @pytest.fixture(scope="module")
@@ -64,21 +64,21 @@ def test_get_category_name_unknown(lang_lookup):
     assert name == "Unbekannt"
 
 
-def test_get_faction_data_known(pictures):
-    data = helpers.get_faction_data(1, pictures)
+def test_get_faction_data_known(lang_lookup):
+    data = helpers.get_faction_data(1, lang_lookup)
     assert data["icon"] == "wcr_undead"
 
 
-def test_get_faction_data_unknown(pictures):
-    assert helpers.get_faction_data(9999, pictures) == {}
+def test_get_faction_data_unknown(lang_lookup):
+    assert helpers.get_faction_data(9999, lang_lookup) == {}
 
 
-def test_get_faction_icon_known(pictures):
-    assert helpers.get_faction_icon(1, pictures) == "wcr_undead"
+def test_get_faction_icon_known(lang_lookup):
+    assert helpers.get_faction_icon(1, lang_lookup) == "wcr_undead"
 
 
-def test_get_faction_icon_unknown(pictures):
-    assert helpers.get_faction_icon(9999, pictures) == ""
+def test_get_faction_icon_unknown(lang_lookup):
+    assert helpers.get_faction_icon(9999, lang_lookup) == ""
 
 
 def test_find_category_id_in_current_lang(lang_lookup):


### PR DESCRIPTION
## Summary
- clean up `pictures.json` to only contain unit images
- simplify category lookup generation in `helpers`
- fetch faction metadata from category lookup
- adjust WCR cog and quiz provider to new helpers
- update tests for new interfaces

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685733349594832fb53eb295cc6fb49d