### PR TITLE
Fix trait names in categories data

### DIFF
--- a/data/wcr/categories.json
+++ b/data/wcr/categories.json
@@ -279,7 +279,7 @@
       "id": 29,
       "names": {
         "de": "Beschuss",
-        "en": "Bomabrd"
+        "en": "Bombard"
       }
     },
     {
@@ -300,14 +300,14 @@
       "id": 32,
       "names": {
         "de": "Tank",
-        "en": "tank"
+        "en": "Tank"
       }
     },
     {
       "id": 33,
       "names": {
         "de": "Blutdurst",
-        "en": "Bloodlist"
+        "en": "Bloodlust"
       }
     },
     {


### PR DESCRIPTION
## Summary
- correct typos in trait names for IDs 29, 32, and 33 in `categories.json`

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685733365a0c832fbe58a35caf43559f