### PR TITLE
Implement language aware output

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -365,11 +365,11 @@ class WCRCog(commands.Cog):
             )
             return
 
-        id_a, data_a, lang_a, texts_a = res_a
-        id_b, data_b, lang_b, texts_b = res_b
+        id_a, data_a, *_ = res_a
+        id_b, data_b, *_ = res_b
 
-        name_a = helpers.get_text_data(id_a, lang_a, self.languages)[0]
-        name_b = helpers.get_text_data(id_b, lang_b, self.languages)[0]
+        name_a = helpers.get_text_data(id_a, lang, self.languages)[0]
+        name_b = helpers.get_text_data(id_b, lang, self.languages)[0]
 
         calculator = DuelCalculator()
 
@@ -474,15 +474,20 @@ class WCRCog(commands.Cog):
         await interaction.followup.send(text, ephemeral=not public)
 
     def create_mini_embed(self, name_or_id, lang):
+        """Baue ein Mini-Embed.
+
+        Lookup erfolgt sprachübergreifend, die Ausgabe richtet sich nach
+        ``lang``.
+        """
         result = self.resolve_unit(name_or_id, lang)
         if not result:
             return None, None
         if lang not in self.languages:
             return None, None
 
-        unit_id, unit_data, lang, texts = result
+        unit_id, unit_data, *_ = result
 
-        return self.build_mini_embed(unit_id, unit_data, lang, texts)
+        return self.build_mini_embed(unit_id, unit_data, lang, self.languages)
 
     def _find_unit_id_by_name(
         self, normalized: str, lang: str
@@ -521,6 +526,11 @@ class WCRCog(commands.Cog):
         return None, lang
 
     def resolve_unit(self, name_or_id, lang):
+        """Finde ein Mini in allen Sprachen.
+
+        Lookup erfolgt sprachübergreifend, die Ausgabe richtet sich nach
+        ``lang``.
+        """
         if lang not in self.languages:
             return None
 


### PR DESCRIPTION
## Summary
- fix language handling for mini embeds and `/wcr duell`
- document cross-language lookup for minis

## Testing
- `black . --quiet`
- `python -m py_compile cogs/wcr/cog.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573a61bd88832f8313b0c2492e5320