### PR TITLE
Update README wcr-lang parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Der Modus `dynamic` passt die Rundenzahl automatisch an und steht nur in Areas m
 Wird kein Level angegeben, verwendet der Bot die Basiswerte (Level 1).
 
 Autocomplete und Fuzzy-Matching erleichtern die Eingabe.
+Der Parameter `lang` bestimmt ausschließlich die Ausgabesprache; die Namenssuche berücksichtigt alle unterstützten Sprachen.
 Alle `/wcr`-Befehle besitzen zusätzlich den Parameter `public`, um die Antwort öffentlich anzuzeigen.
 
 ### `/ptcgp`


### PR DESCRIPTION
## Summary
- document what the `lang` parameter does in `/wcr`

## Testing
- `black .`
- `python - <<'PY' ...`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573a6eb630832f88aed6e9720d9484