### PR TITLE
Add language-aware /wcr name test

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -477,10 +477,12 @@ class WCRCog(commands.Cog):
         result = self.resolve_unit(name_or_id, lang)
         if not result:
             return None, None
-        if lang not in self.languages:
-            return None, None
+        unit_id, unit_data, found_lang, _texts = result
 
-        unit_id, unit_data, lang, texts = result
+        if lang not in self.languages:
+            lang = found_lang
+
+        texts = self.languages.get(lang, self.languages[found_lang])
 
         return self.build_mini_embed(unit_id, unit_data, lang, texts)
 

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -107,6 +107,19 @@ async def test_cmd_name_creates_embed():
     cog.cog_unload()
 
 
+@pytest.mark.asyncio
+async def test_cmd_name_respects_lang(monkeypatch):
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_name(inter, "Abscheulichkeit", lang="en")
+
+    embed = inter.followup.sent[0]["embed"]
+    assert embed.title.strip() == "Abomination"
+    cog.cog_unload()
+
+
 def test_name_map_contains_unit():
     bot = DummyBot()
     cog = WCRCog(bot)


### PR DESCRIPTION
## Summary
- ensure `/wcr name` returns text in the requested language
- fix `create_mini_embed` to prefer the passed language
- add async test for language awareness in `/wcr name`

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573a7cf9bc832faec3e3b8156b58f2