### PR TITLE
Dokumentation zu Emoji-Export ergänzt

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,12 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **WCR-Modul** verarbeitet die Daten unter `data/wcr/` und nutzt sie für Autocomplete sowie dynamische Fragen.  
   - `units.json` enthält alle Minis samt Werten und mehrsprachigen Texten.  
   - `categories.json` definiert Fraktionen, Typen, Geschwindigkeiten und Traits.  
-  - `stat_labels.json` übersetzt die Statistik-Bezeichnungen.  
-  - `pictures.json` ordnet jedem Mini ein Icon zu.  
+  - `stat_labels.json` übersetzt die Statistik-Bezeichnungen.
+  - `pictures.json` ordnet jedem Mini ein Icon zu.
   - Die Fragevorlagen liegen unter `data/quiz/templates/wcr.json`.
+  - Beim Start erzeugt `_export_emojis` automatisch `data/emojis.json`; die darin
+    hinterlegten Emoji-Namen müssen mit den Angaben in `data/wcr/categories.json`
+    übereinstimmen.
 - Alle Slash-Commands werden **guild-basiert** registriert und nur für die Haupt-Guild synchronisiert.
 
 Persistente Daten liegen in `data/pers/` und sollten nicht ins Repository aufgenommen werden.


### PR DESCRIPTION
## Summary
- füge in der Architektur-Beschreibung einen Hinweis zum automatischen Export der Server‑Emojis ein
- erwähne, dass die Emoji-Namen mit `categories.json` übereinstimmen müssen

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68573a7ff9ec832f87d6a80de1532b9a