### PR TITLE
Adjust resolve_unit return type

### DIFF
--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -365,8 +365,8 @@ class WCRCog(commands.Cog):
             )
             return
 
-        id_a, data_a, *_ = res_a
-        id_b, data_b, *_ = res_b
+        id_a, data_a, _ = res_a
+        id_b, data_b, _ = res_b
 
         name_a = helpers.get_text_data(id_a, lang, self.languages)[0]
         name_b = helpers.get_text_data(id_b, lang, self.languages)[0]
@@ -485,9 +485,9 @@ class WCRCog(commands.Cog):
         if lang not in self.languages:
             return None, None
 
-        unit_id, unit_data, *_ = result
+        unit_id, unit_data, _ = result
 
-        return self.build_mini_embed(unit_id, unit_data, lang, self.languages)
+        return self.build_mini_embed(unit_id, unit_data, lang)
 
     def _find_unit_id_by_name(
         self, normalized: str, lang: str
@@ -544,7 +544,6 @@ class WCRCog(commands.Cog):
             name, _, _ = helpers.get_text_data(unit_id, lang, self.languages)
             if name == "Unbekannt":
                 return None
-            texts = self.languages[lang]
         except ValueError:
             normalized = " ".join(helpers.normalize_name(name_or_id))
             unit_id, lang = self._find_unit_id_by_name(normalized, lang)
@@ -557,10 +556,7 @@ class WCRCog(commands.Cog):
                     )
                     if unit_id is not None:
                         lang = found_lang
-                        texts = self.languages[found_lang]
                         break
-            else:
-                texts = self.languages[lang]
             if unit_id is None:
                 return None
 
@@ -570,7 +566,7 @@ class WCRCog(commands.Cog):
             if not unit_data:
                 return None
 
-        return unit_id, unit_data, lang, texts
+        return unit_id, unit_data, lang
 
     # Helper methods -----------------------------------------------------
     def _prepare_stat_rows(self, unit_data, stat_labels, type_name, speed_name):
@@ -743,7 +739,7 @@ class WCRCog(commands.Cog):
             "inline": False,
         }
 
-    def build_mini_embed(self, unit_id, unit_data, lang, texts):
+    def build_mini_embed(self, unit_id, unit_data, lang):
         unit_name, unit_description, talents = helpers.get_text_data(
             unit_id, lang, self.languages
         )

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -138,7 +138,7 @@ def test_resolve_unit_cross_language():
 
     result = cog.resolve_unit("Abomination", "de")
     assert result is not None
-    unit_id, _, lang, _ = result
+    unit_id, _, lang = result
     assert unit_id == 1
     assert lang == "en"
     cog.cog_unload()
@@ -150,7 +150,7 @@ def test_resolve_unit_fuzzy_partial():
 
     result = cog.resolve_unit("sylvanas", "de")
     assert result is not None
-    unit_id, _, lang, _ = result
+    unit_id, _, lang = result
     assert unit_id == 62
     assert lang == "de"
     cog.cog_unload()
@@ -162,7 +162,7 @@ def test_resolve_unit_cross_language_fuzzy():
 
     result = cog.resolve_unit("windrunner", "de")
     assert result is not None
-    unit_id, _, lang, _ = result
+    unit_id, _, lang = result
     assert unit_id == 62
     assert lang == "en"
     cog.cog_unload()


### PR DESCRIPTION
## Summary
- simplify `resolve_unit` return value
- adapt callers and tests for the new format

## Testing
- `python -m py_compile cogs/wcr/cog.py tests/wcr/test_wcr_cog.py`
- `black . --quiet`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685741598930832fb67b0e94ab220ee4