### PR TITLE
Add test for English translation

### DIFF
--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -107,6 +107,19 @@ async def test_cmd_name_creates_embed():
     cog.cog_unload()
 
 
+@pytest.mark.asyncio
+async def test_cmd_name_respects_lang(monkeypatch):
+    bot = DummyBot()
+    cog = WCRCog(bot)
+    inter = DummyInteraction()
+
+    await cog.cmd_name(inter, "Abscheulichkeit", lang="en")
+
+    embed = inter.followup.sent[0]["embed"]
+    assert embed.title.strip() == "Abomination"
+    cog.cog_unload()
+
+
 def test_name_map_contains_unit():
     bot = DummyBot()
     cog = WCRCog(bot)


### PR DESCRIPTION
## Summary
- cover WCRCog cmd_name to ensure language parameter is respected

## Testing
- `black .`
- `python -m py_compile tests/wcr/test_wcr_cog.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685743401a90832fa3182bc252e1efe8