### PR TITLE
Introduce helper for cog setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
     Datei enthält ein einfaches Mapping `{name: syntax}`. Die Emoji-Namen müssen
     mit den Angaben in `data/wcr/categories.json` übereinstimmen.
 - Alle Slash-Commands werden **guild-basiert** registriert und nur für die Haupt-Guild synchronisiert.
+- Zur Vereinfachung der Registrierung stellt `utils.setup_helpers.register_cog_and_group` eine Hilfsfunktion bereit.
 
 Persistente Daten liegen in `data/pers/` und sollten nicht ins Repository aufgenommen werden.
 

--- a/cogs/champion/__init__.py
+++ b/cogs/champion/__init__.py
@@ -3,20 +3,17 @@ import discord
 from log_setup import get_logger
 
 from .cog import ChampionCog
+from utils.setup_helpers import register_cog_and_group
 
 logger = get_logger(__name__)
 
 
 async def setup(bot: discord.ext.commands.Bot):
-    """Register cog and slash command group for the champion system."""
+    """Registriert Cog und Slash-Befehle für das Champion-System."""
     try:
         from .slash_commands import champion_group, syncroles
 
-        # 1) Haupt-Cog: Champion-Daten und Rolle-Logik
-        await bot.add_cog(ChampionCog(bot))
-
-        # 2) Slash-Gruppe /champion in den Command-Tree einfügen
-        bot.tree.add_command(champion_group, guild=bot.main_guild)
+        await register_cog_and_group(bot, ChampionCog, champion_group)
         bot.tree.add_command(syncroles, guild=bot.main_guild)
 
         logger.info(

--- a/cogs/ptcgp/__init__.py
+++ b/cogs/ptcgp/__init__.py
@@ -3,17 +3,17 @@ import discord
 from log_setup import get_logger
 
 from .cog import PTCGPCog
+from utils.setup_helpers import register_cog_and_group
 
 logger = get_logger(__name__)
 
 
 async def setup(bot: discord.ext.commands.Bot):
-    """Register the PTCGP cog and its slash commands."""
+    """Registriert Cog und Slash-Befehle für PTCGP."""
     try:
         from .slash_commands import ptcgp_group
 
-        await bot.add_cog(PTCGPCog(bot))
-        bot.tree.add_command(ptcgp_group, guild=bot.main_guild)
+        await register_cog_and_group(bot, PTCGPCog, ptcgp_group)
         logger.info("[PTCGPCog] Cog und Slash-Command-Gruppe erfolgreich registriert.")
     except Exception as e:
         logger.error(f"[PTCGPCog] Fehler beim Setup: {e}", exc_info=True)

--- a/cogs/quiz/__init__.py
+++ b/cogs/quiz/__init__.py
@@ -4,17 +4,16 @@ from log_setup import get_logger
 
 from .cog import QuizCog
 from .slash_commands import quiz_group
+from utils.setup_helpers import register_cog_and_group
 
 
 logger = get_logger(__name__)
 
 
 async def setup(bot: commands.Bot):
-    """Set up the quiz cog and slash commands."""
+    """Setzt das Quiz-Cog auf und registriert die Slash-Befehle."""
     logger.info("[QuizInit] Initialisierung startet...")
 
-    quiz_cog = QuizCog(bot)
-    await bot.add_cog(quiz_cog, override=True)
-    bot.tree.add_command(quiz_group, guild=bot.main_guild)
+    await register_cog_and_group(bot, QuizCog, quiz_group)
 
     logger.info("[QuizInit] Cog und Slash-Command-Gruppe erfolgreich registriert.")

--- a/cogs/wcr/__init__.py
+++ b/cogs/wcr/__init__.py
@@ -5,17 +5,17 @@ import discord
 from log_setup import get_logger
 
 from .cog import WCRCog
+from utils.setup_helpers import register_cog_and_group
 
 logger = get_logger(__name__)  # z.B. "cogs.wcr.__init__"
 
 
 async def setup(bot: discord.ext.commands.Bot):
-    """Register the WCR cog and its slash commands."""
+    """Registriert Cog und Slash-Befehle für WCR."""
     try:
         from .slash_commands import wcr_group
 
-        await bot.add_cog(WCRCog(bot))
-        bot.tree.add_command(wcr_group, guild=bot.main_guild)
+        await register_cog_and_group(bot, WCRCog, wcr_group)
         logger.info("[WCRCog] Cog und Slash-Command-Gruppe erfolgreich registriert.")
     except Exception as e:
         logger.error(f"[WCRCog] Fehler beim Setup: {e}", exc_info=True)

--- a/utils/setup_helpers.py
+++ b/utils/setup_helpers.py
@@ -1,4 +1,3 @@
-import discord
 from discord import app_commands
 from discord.ext import commands
 

--- a/utils/setup_helpers.py
+++ b/utils/setup_helpers.py
@@ -1,0 +1,11 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+async def register_cog_and_group(
+    bot: commands.Bot, cog_cls: type[commands.Cog], slash_group: app_commands.Group
+) -> None:
+    """Fügt ein Cog hinzu und registriert eine Slash-Command-Gruppe für die Haupt-Guild."""
+    await bot.add_cog(cog_cls(bot))
+    bot.tree.add_command(slash_group, guild=bot.main_guild)


### PR DESCRIPTION
## Summary
- add `register_cog_and_group` helper
- use helper in cog setup modules
- document new helper in the README

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685864afd94c832f908a7796a82d5d1c