### PR TITLE
Implement async WCR data loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,7 @@
 bot_key=DEIN_DISCORD_TOKEN
 server_id=DEINE_SERVER_ID
 LOG_LEVEL=INFO
+# Basis-URL der WCR-API
+WCR_API_URL=https://wcr-api.up.railway.app
 # Optional: Ignoriert Zertifikatsfehler der PTCGP-API
 PTCGP_SKIP_SSL_VERIFY=0

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Die wichtigsten Variablen aus `.env`:
 bot_key=DISCORD_BOT_TOKEN
 server_id=DEINE_GUILD_ID
 LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
+# Basis-URL der WCR-API
+WCR_API_URL=https://wcr-api.up.railway.app
 # Bei Zertifikatsproblemen kann die Überprüfung für die PTCGP-API deaktiviert werden
 PTCGP_SKIP_SSL_VERIFY=0
 ```
@@ -144,11 +146,8 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
 - **Champion-System** speichert Punkte in SQLite und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
-- **WCR-Modul** verarbeitet die Daten unter `data/wcr/` und nutzt sie für Autocomplete sowie dynamische Fragen.  
-  - `units.json` enthält alle Minis samt Werten und mehrsprachigen Texten.  
-  - `categories.json` definiert Fraktionen, Typen, Geschwindigkeiten und Traits.  
-  - `stat_labels.json` übersetzt die Statistik-Bezeichnungen.
-  - `pictures.json` ordnet jedem Mini ein Icon zu.
+ - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
+  - Die API stellt ``units``, ``categories``, ``pictures`` und ``stat_labels`` bereit.
   - Die Fragevorlagen liegen unter `data/quiz/templates/wcr.json`.
   - Beim Start erzeugt `_export_emojis` automatisch `data/emojis.json`; diese
     Datei enthält ein einfaches Mapping `{name: syntax}`. Die Emoji-Namen müssen

--- a/bot.py
+++ b/bot.py
@@ -139,7 +139,7 @@ class MyBot(commands.Bot):
                 quiz_templates[f.stem] = load_json(f)
 
         # WCR-Daten zentral laden
-        wcr_data = load_wcr_data()
+        wcr_data = await load_wcr_data()
 
         # Champion-Rollen laden
         champion_roles = load_json("data/champion/roles.json")

--- a/tests/general/test_bot_setup.py
+++ b/tests/general/test_bot_setup.py
@@ -16,7 +16,11 @@ async def test_setup_hook_clears_global_commands(monkeypatch, bot):
     monkeypatch.setattr(bot.tree, "sync", fake_sync)
 
     monkeypatch.setattr("bot.load_json", lambda path: {})
-    monkeypatch.setattr("bot.load_wcr_data", lambda: {})
+
+    async def fake_load():
+        return {}
+
+    monkeypatch.setattr("bot.load_wcr_data", fake_load)
     monkeypatch.setattr("bot.load_quiz_config", lambda b: None)
 
     async def nop(bot):

--- a/tests/quiz/test_wcr_provider.py
+++ b/tests/quiz/test_wcr_provider.py
@@ -6,31 +6,30 @@ import log_setup
 
 from cogs.quiz.area_providers.wcr import WCRQuestionProvider
 from cogs.quiz.utils import create_permutations_list
-from cogs.wcr.utils import load_wcr_data
 
 
-def create_bot():
+def create_bot(wcr_data):
     with open(Path("data/quiz/templates/wcr.json"), "r", encoding="utf-8") as f:
         templates = json.load(f)
-    return DummyBot(templates)
+    return DummyBot(templates, wcr_data)
 
 
-def create_provider():
-    bot = create_bot()
+def create_provider(wcr_data):
+    bot = create_bot(wcr_data)
     return bot, WCRQuestionProvider(bot, language="de")
 
 
 class DummyBot:
-    def __init__(self, templates):
+    def __init__(self, templates, wcr_data):
         self.data = {
-            "wcr": load_wcr_data(),
+            "wcr": wcr_data,
             "quiz": {"templates": {"wcr": templates}},
         }
 
 
-def test_generate_type_1(monkeypatch, patch_logged_task):
+def test_generate_type_1(wcr_data, monkeypatch, patch_logged_task):
     patch_logged_task(log_setup)
-    bot, provider = create_provider()
+    bot, provider = create_provider(wcr_data)
     first_unit = provider.locals["de"]["units"][0]
     first_talent = first_unit["talents"][0]
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
@@ -50,9 +49,9 @@ def test_generate_type_1(monkeypatch, patch_logged_task):
     assert provider.generate_type_1() is None
 
 
-def test_generate_type_2(monkeypatch, patch_logged_task):
+def test_generate_type_2(wcr_data, monkeypatch, patch_logged_task):
     patch_logged_task(log_setup)
-    bot, provider = create_provider()
+    bot, provider = create_provider(wcr_data)
     first_talent = provider.locals["de"]["units"][0]["talents"][0]
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
@@ -70,9 +69,9 @@ def test_generate_type_2(monkeypatch, patch_logged_task):
     assert provider.generate_type_2() is None
 
 
-def test_generate_type_3(monkeypatch, patch_logged_task):
+def test_generate_type_3(wcr_data, monkeypatch, patch_logged_task):
     patch_logged_task(log_setup)
-    bot, provider = create_provider()
+    bot, provider = create_provider(wcr_data)
     first_unit = provider.units[0]
     first_unit_name = provider.locals["de"]["units"][0]["name"]
     faction_lookup = provider.lang_category_lookup["de"]["factions"]
@@ -93,9 +92,9 @@ def test_generate_type_3(monkeypatch, patch_logged_task):
     assert provider.generate_type_3() is None
 
 
-def test_generate_type_4(monkeypatch, patch_logged_task):
+def test_generate_type_4(wcr_data, monkeypatch, patch_logged_task):
     patch_logged_task(log_setup)
-    bot, provider = create_provider()
+    bot, provider = create_provider(wcr_data)
     first_unit = provider.units[0]
     first_unit_name = provider.locals["de"]["units"][0]["name"]
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
@@ -114,9 +113,9 @@ def test_generate_type_4(monkeypatch, patch_logged_task):
     assert provider.generate_type_4() is None
 
 
-def test_generate_type_5(monkeypatch, patch_logged_task):
+def test_generate_type_5(wcr_data, monkeypatch, patch_logged_task):
     patch_logged_task(log_setup)
-    bot, provider = create_provider()
+    bot, provider = create_provider(wcr_data)
     monkeypatch.setattr(random, "choice", lambda seq: "health")
     monkeypatch.setattr(random, "sample", lambda seq, k: seq[:k])
 

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -8,10 +8,8 @@ from cogs.wcr.duel import DuelCalculator
 
 
 class DummyBot:
-    def __init__(self):
-        from cogs.wcr.utils import load_wcr_data
-
-        self.data = {"emojis": {}, "wcr": load_wcr_data()}
+    def __init__(self, wcr_data):
+        self.data = {"emojis": {}, "wcr": wcr_data}
 
 
 class DummyResponse:
@@ -42,8 +40,8 @@ class DummyInteraction:
 
 
 @pytest.mark.asyncio
-async def test_cmd_filter_no_emojis():
-    bot = DummyBot()
+async def test_cmd_filter_no_emojis(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -59,8 +57,8 @@ async def test_cmd_filter_no_emojis():
 
 
 @pytest.mark.asyncio
-async def test_cmd_filter_generates_options():
-    bot = DummyBot()
+async def test_cmd_filter_generates_options(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -87,8 +85,8 @@ async def test_cmd_filter_generates_options():
 
 
 @pytest.mark.asyncio
-async def test_cmd_name_creates_embed():
-    bot = DummyBot()
+async def test_cmd_name_creates_embed(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -108,8 +106,8 @@ async def test_cmd_name_creates_embed():
 
 
 @pytest.mark.asyncio
-async def test_cmd_name_respects_lang(monkeypatch):
-    bot = DummyBot()
+async def test_cmd_name_respects_lang(wcr_data, monkeypatch):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -120,15 +118,15 @@ async def test_cmd_name_respects_lang(monkeypatch):
     cog.cog_unload()
 
 
-def test_name_map_contains_unit():
-    bot = DummyBot()
+def test_name_map_contains_unit(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     assert cog.unit_name_map["de"]["abscheulichkeit"] == 1
     cog.cog_unload()
 
 
-def test_build_mini_embed_uses_emoji():
-    bot = DummyBot()
+def test_build_mini_embed_uses_emoji(wcr_data):
+    bot = DummyBot(wcr_data)
     bot.data["emojis"] = {"wcr_undead": "<:wcr_undead:id>"}
     cog = WCRCog(bot)
     units = bot.data["wcr"]["units"]
@@ -140,8 +138,8 @@ def test_build_mini_embed_uses_emoji():
     cog.cog_unload()
 
 
-def test_category_lookups_created():
-    bot = DummyBot()
+def test_category_lookups_created(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     assert "factions" in cog.lang_category_lookup["de"]
@@ -150,16 +148,16 @@ def test_category_lookups_created():
     cog.cog_unload()
 
 
-def test_token_index_contains_token():
-    bot = DummyBot()
+def test_token_index_contains_token(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     assert 62 in cog.name_token_index["de"]["sylvanas"]
     cog.cog_unload()
 
 
-def test_resolve_unit_cross_language():
-    bot = DummyBot()
+def test_resolve_unit_cross_language(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     result = cog.resolve_unit("Abomination", "de")
@@ -170,8 +168,8 @@ def test_resolve_unit_cross_language():
     cog.cog_unload()
 
 
-def test_resolve_unit_fuzzy_partial():
-    bot = DummyBot()
+def test_resolve_unit_fuzzy_partial(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     result = cog.resolve_unit("sylvanas", "de")
@@ -182,8 +180,8 @@ def test_resolve_unit_fuzzy_partial():
     cog.cog_unload()
 
 
-def test_resolve_unit_cross_language_fuzzy():
-    bot = DummyBot()
+def test_resolve_unit_cross_language_fuzzy(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     result = cog.resolve_unit("windrunner", "de")
@@ -195,8 +193,8 @@ def test_resolve_unit_cross_language_fuzzy():
 
 
 @pytest.mark.asyncio
-async def test_select_view_timeout_disables_select():
-    bot = DummyBot()
+async def test_select_view_timeout_disables_select(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -212,8 +210,8 @@ async def test_select_view_timeout_disables_select():
     cog.cog_unload()
 
 
-def test_init_without_en_language(caplog):
-    bot = DummyBot()
+def test_init_without_en_language(wcr_data, caplog):
+    bot = DummyBot(wcr_data)
     del bot.data["wcr"]["locals"]["en"]
 
     with caplog.at_level(logging.WARNING):
@@ -225,8 +223,8 @@ def test_init_without_en_language(caplog):
 
 
 @pytest.mark.asyncio
-async def test_cost_autocomplete_returns_all():
-    bot = DummyBot()
+async def test_cost_autocomplete_returns_all(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -239,8 +237,8 @@ async def test_cost_autocomplete_returns_all():
 
 
 @pytest.mark.asyncio
-async def test_speed_autocomplete_matches_substring():
-    bot = DummyBot()
+async def test_speed_autocomplete_matches_substring(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -252,8 +250,8 @@ async def test_speed_autocomplete_matches_substring():
 
 
 @pytest.mark.asyncio
-async def test_faction_autocomplete_case_insensitive():
-    bot = DummyBot()
+async def test_faction_autocomplete_case_insensitive(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -266,8 +264,8 @@ async def test_faction_autocomplete_case_insensitive():
 
 
 @pytest.mark.asyncio
-async def test_type_autocomplete_multiple_results():
-    bot = DummyBot()
+async def test_type_autocomplete_multiple_results(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -279,8 +277,8 @@ async def test_type_autocomplete_multiple_results():
 
 
 @pytest.mark.asyncio
-async def test_trait_autocomplete_returns_sorted_matches():
-    bot = DummyBot()
+async def test_trait_autocomplete_returns_sorted_matches(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -292,8 +290,8 @@ async def test_trait_autocomplete_returns_sorted_matches():
 
 
 @pytest.mark.asyncio
-async def test_unit_name_autocomplete_multilang():
-    bot = DummyBot()
+async def test_unit_name_autocomplete_multilang(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -311,8 +309,8 @@ async def test_unit_name_autocomplete_multilang():
     cog.cog_unload()
 
 
-def test_scaled_stats_leveling():
-    bot = DummyBot()
+def test_scaled_stats_leveling(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     calculator = DuelCalculator()
 
@@ -333,8 +331,8 @@ def test_scaled_stats_leveling():
     cog.cog_unload()
 
 
-def test_duel_result_flying_vs_melee():
-    bot = DummyBot()
+def test_duel_result_flying_vs_melee(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     units = bot.data["wcr"]["units"]
@@ -349,8 +347,8 @@ def test_duel_result_flying_vs_melee():
     cog.cog_unload()
 
 
-def test_compute_dps_spell_hits_flying():
-    bot = DummyBot()
+def test_compute_dps_spell_hits_flying(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     units = bot.data["wcr"]["units"]
@@ -368,8 +366,8 @@ def test_compute_dps_spell_hits_flying():
     cog.cog_unload()
 
 
-def test_duel_result_spell_vs_mini():
-    bot = DummyBot()
+def test_duel_result_spell_vs_mini(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     units = bot.data["wcr"]["units"]
@@ -385,8 +383,8 @@ def test_duel_result_spell_vs_mini():
     cog.cog_unload()
 
 
-def test_duel_result_equal_damage_spells():
-    bot = DummyBot()
+def test_duel_result_equal_damage_spells(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     units = bot.data["wcr"]["units"]
@@ -402,8 +400,8 @@ def test_duel_result_equal_damage_spells():
     cog.cog_unload()
 
 
-def test_duel_result_identical_minis():
-    bot = DummyBot()
+def test_duel_result_identical_minis(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
 
     units = bot.data["wcr"]["units"]
@@ -419,8 +417,8 @@ def test_duel_result_identical_minis():
 
 
 @pytest.mark.asyncio
-async def test_cmd_filter_public():
-    bot = DummyBot()
+async def test_cmd_filter_public(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -434,8 +432,8 @@ async def test_cmd_filter_public():
 
 
 @pytest.mark.asyncio
-async def test_cmd_name_public():
-    bot = DummyBot()
+async def test_cmd_name_public(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -447,8 +445,8 @@ async def test_cmd_name_public():
 
 
 @pytest.mark.asyncio
-async def test_cmd_duel_public():
-    bot = DummyBot()
+async def test_cmd_duel_public(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -471,8 +469,8 @@ async def test_cmd_duel_public():
 
 
 @pytest.mark.asyncio
-async def test_cmd_duel_no_damage_message():
-    bot = DummyBot()
+async def test_cmd_duel_no_damage_message(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -492,8 +490,8 @@ async def test_cmd_duel_no_damage_message():
 
 
 @pytest.mark.asyncio
-async def test_cmd_duel_identical_minis_tie():
-    bot = DummyBot()
+async def test_cmd_duel_identical_minis_tie(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 
@@ -513,8 +511,8 @@ async def test_cmd_duel_identical_minis_tie():
 
 
 @pytest.mark.asyncio
-async def test_cmd_duel_unknown_mini():
-    bot = DummyBot()
+async def test_cmd_duel_unknown_mini(wcr_data):
+    bot = DummyBot(wcr_data)
     cog = WCRCog(bot)
     inter = DummyInteraction()
 

--- a/tests/wcr/test_wcr_helpers.py
+++ b/tests/wcr/test_wcr_helpers.py
@@ -1,33 +1,28 @@
-import json
 import pytest
 
 
 from cogs.wcr import helpers
 
 
-@pytest.fixture(scope="module")
-def languages():
-    from cogs.wcr.utils import load_languages
-
-    return load_languages()
+@pytest.fixture
+def languages(wcr_data):
+    return wcr_data["locals"]
 
 
-@pytest.fixture(scope="module")
-def categories():
-    from cogs.wcr.utils import load_categories
-
-    return load_categories()
+@pytest.fixture
+def categories(wcr_data):
+    return wcr_data["categories"]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def lang_lookup(categories):
     """Erzeuge die Kategorie-Lookup-Tabelle für die Tests."""
     return helpers.build_category_lookup(categories)
 
 
-@pytest.fixture(scope="module")
-def pictures():
-    return json.load(open("data/wcr/pictures.json", "r", encoding="utf-8"))
+@pytest.fixture
+def pictures(wcr_data):
+    return wcr_data["pictures"]
 
 
 def test_get_text_data_known(languages):

--- a/tests/wcr/test_wcr_question_provider.py
+++ b/tests/wcr/test_wcr_question_provider.py
@@ -10,47 +10,45 @@ class DummyBot:
     pass
 
 
-def create_provider():
+def create_provider(wcr_data):
     bot = DummyBot()
-    from cogs.wcr.utils import load_wcr_data
-
     from pathlib import Path
 
     with open(Path("data/quiz/templates/wcr.json"), "r", encoding="utf-8") as f:
         templates = json.load(f)
 
-    bot.data = {"wcr": load_wcr_data(), "quiz": {"templates": {"wcr": templates}}}
+    bot.data = {"wcr": wcr_data, "quiz": {"templates": {"wcr": templates}}}
     return WCRQuestionProvider(bot, language="de")
 
 
-def test_provider_inherits_base():
-    provider = create_provider()
+def test_provider_inherits_base(wcr_data):
+    provider = create_provider(wcr_data)
     assert isinstance(provider, DynamicQuestionProvider)
 
 
-def test_generate_type_1():
-    provider = create_provider()
+def test_generate_type_1(wcr_data):
+    provider = create_provider(wcr_data)
     q = provider.generate_type_1()
     assert q is not None
     assert "frage" in q and "antwort" in q and "id" in q
 
 
-def test_generate_type_2():
-    provider = create_provider()
+def test_generate_type_2(wcr_data):
+    provider = create_provider(wcr_data)
     q = provider.generate_type_2()
     assert q is not None
     assert "frage" in q and "antwort" in q and "id" in q
 
 
-def test_generate_type_3():
-    provider = create_provider()
+def test_generate_type_3(wcr_data):
+    provider = create_provider(wcr_data)
     q = provider.generate_type_3()
     assert q is not None
     assert "frage" in q and "antwort" in q and "id" in q
 
 
-def test_generate_type_4(monkeypatch):
-    provider = create_provider()
+def test_generate_type_4(wcr_data, monkeypatch):
+    provider = create_provider(wcr_data)
     # make selection deterministic
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
     q = provider.generate_type_4()
@@ -58,8 +56,8 @@ def test_generate_type_4(monkeypatch):
     assert "frage" in q and "antwort" in q and "id" in q
 
 
-def test_generate_type_5(monkeypatch):
-    provider = create_provider()
+def test_generate_type_5(wcr_data, monkeypatch):
+    provider = create_provider(wcr_data)
     monkeypatch.setattr(random, "choice", lambda seq: "damage")
     monkeypatch.setattr(random, "sample", lambda seq, k: seq[:k])
     q = provider.generate_type_5()
@@ -67,8 +65,8 @@ def test_generate_type_5(monkeypatch):
     assert "frage" in q and "antwort" in q and "id" in q
 
 
-def test_generate_type_5_requires_two_units(monkeypatch):
-    provider = create_provider()
+def test_generate_type_5_requires_two_units(wcr_data, monkeypatch):
+    provider = create_provider(wcr_data)
     units = provider.units
     provider.units = [units[1], units[3]]
 
@@ -82,8 +80,8 @@ def test_generate_type_5_requires_two_units(monkeypatch):
     assert q is None
 
 
-def test_generate_all_types(monkeypatch):
-    provider = create_provider()
+def test_generate_all_types(wcr_data, monkeypatch):
+    provider = create_provider(wcr_data)
 
     monkeypatch.setattr(
         provider, "generate_type_1", lambda: {"frage": "f1", "antwort": "a", "id": 1}


### PR DESCRIPTION
## Summary
- fetch WCR data asynchronously from configured API
- integrate asynchronous loading in bot setup
- mock WCR API in tests and adjust fixtures
- document new `WCR_API_URL` setting

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859f38b65b4832fad1685de48d68635