### PR TITLE
Add WCR image base configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,7 @@ server_id=DEINE_SERVER_ID
 LOG_LEVEL=INFO
 # Basis-URL der WCR-API
 WCR_API_URL=https://wcr-api.up.railway.app
+# Basis-URL f\u00fcr Bilder (Standard: https://www.method.gg)
+WCR_IMAGE_BASE=https://www.method.gg
 # Optional: Ignoriert Zertifikatsfehler der PTCGP-API
 PTCGP_SKIP_SSL_VERIFY=0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ server_id=DEINE_GUILD_ID
 LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
 # Basis-URL der WCR-API
 WCR_API_URL=https://wcr-api.up.railway.app
+# Basis-URL für Bilder (Standard: https://www.method.gg)
+WCR_IMAGE_BASE=https://www.method.gg
 # Bei Zertifikatsproblemen kann die Überprüfung für die PTCGP-API deaktiviert werden
 PTCGP_SKIP_SSL_VERIFY=0
 ```
@@ -146,7 +148,8 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
 - **Champion-System** speichert Punkte in SQLite und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
- - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
+- **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
+  - Bilder werden relativ zu ``WCR_IMAGE_BASE`` aufgel\u00f6st.
   - Die API stellt ``units``, ``categories``, ``pictures`` und ``stat_labels`` bereit.
   - Die Fragevorlagen liegen unter `data/quiz/templates/wcr.json`.
   - Beim Start erzeugt `_export_emojis` automatisch `data/emojis.json`; diese

--- a/cogs/wcr/helpers.py
+++ b/cogs/wcr/helpers.py
@@ -1,6 +1,8 @@
 # cogs/wcr/helpers.py
 
 
+import os
+
 from log_setup import get_logger
 
 logger = get_logger(__name__)
@@ -41,11 +43,21 @@ def get_text_data(unit_id: int, lang: str, languages: dict) -> tuple[str, str, l
     )
 
 
+def _normalize_image_url(path: str) -> str:
+    """Gibt eine vollst\u00e4ndige URL f\u00fcr ``path`` zur\u00fcck."""
+
+    base = os.getenv("WCR_IMAGE_BASE", "https://www.method.gg")
+    if path and not path.startswith("http"):
+        return f"{base.rstrip('/')}/{path.lstrip('/')}"
+    return path
+
+
 def get_pose_url(unit_id: int, pictures: dict) -> str:
-    """Return the pose image URL for a unit."""
+    """Gibt die URL des Pose-Bildes einer Einheit zur\u00fcck."""
     unit_pictures = pictures.get("units", [])
     unit_picture = next((pic for pic in unit_pictures if pic["id"] == unit_id), {})
-    return unit_picture.get("pose", "")
+    url = unit_picture.get("pose", "")
+    return _normalize_image_url(url)
 
 
 def get_faction_data(faction_id: int, lang_lookup: dict) -> dict:

--- a/tests/wcr/test_wcr_helpers.py
+++ b/tests/wcr/test_wcr_helpers.py
@@ -49,6 +49,20 @@ def test_get_pose_url_unknown(pictures):
     assert helpers.get_pose_url(9999, pictures) == ""
 
 
+def test_get_pose_url_relative_default_base(pictures, monkeypatch):
+    pictures["units"][0]["pose"] = "images/test.webp"
+    monkeypatch.delenv("WCR_IMAGE_BASE", raising=False)
+    url = helpers.get_pose_url(1, pictures)
+    assert url == "https://www.method.gg/images/test.webp"
+
+
+def test_get_pose_url_relative_custom_base(pictures, monkeypatch):
+    pictures["units"][0]["pose"] = "/img/foobar.webp"
+    monkeypatch.setenv("WCR_IMAGE_BASE", "https://cdn.example.com")
+    url = helpers.get_pose_url(1, pictures)
+    assert url == "https://cdn.example.com/img/foobar.webp"
+
+
 def test_get_category_name_known(lang_lookup):
     name = helpers.get_category_name("factions", 1, "de", lang_lookup)
     assert name == "Untote"


### PR DESCRIPTION
## Summary
- support optional `WCR_IMAGE_BASE` for images
- document the variable in `.env.example` and README
- build URLs from relative paths in `get_pose_url`
- extend tests for new behaviour

## Testing
- `python -m py_compile cogs/wcr/helpers.py tests/wcr/test_wcr_helpers.py`
- `black . --quiet`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859fec21f40832f8d641c2d06ea0b04