### PR TITLE
Verbessere WCR-Datenabruf

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
   - Bilder werden relativ zu ``WCR_IMAGE_BASE`` aufgel\u00f6st.
   - Die API stellt ``units``, ``categories``, ``pictures`` und ``stat_labels`` bereit.
+  - Beim Abrufen dieser Daten wird ein Timeout von 10 Sekunden verwendet.
   - Die Fragevorlagen liegen unter `data/quiz/templates/wcr.json`.
   - Beim Start erzeugt `_export_emojis` automatisch `data/emojis.json`; diese
     Datei enthält ein einfaches Mapping `{name: syntax}`. Die Emoji-Namen müssen

--- a/tests/wcr/test_utils_fetch.py
+++ b/tests/wcr/test_utils_fetch.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+
+import aiohttp
+import pytest
+
+from cogs.wcr.utils import fetch_wcr_data
+
+
+@pytest.mark.asyncio
+async def test_fetch_concurrent(monkeypatch):
+    start_events = [asyncio.Event() for _ in range(4)]
+    release = asyncio.Event()
+
+    class DummyResponse:
+        def __init__(self, idx):
+            self.idx = idx
+
+        async def __aenter__(self):
+            start_events[self.idx].set()
+            await release.wait()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def json(self):
+            return {"id": self.idx}
+
+        def raise_for_status(self):
+            pass
+
+    class DummySession:
+        def __init__(self, *args, **kwargs):
+            self.count = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url):
+            resp = DummyResponse(self.count)
+            self.count += 1
+            return resp
+
+    monkeypatch.setattr(
+        "cogs.wcr.utils.aiohttp.ClientSession",
+        lambda *args, **kwargs: DummySession(*args, **kwargs),
+    )
+
+    task = asyncio.create_task(fetch_wcr_data("http://test"))
+    await asyncio.wait_for(
+        asyncio.gather(*(e.wait() for e in start_events)), timeout=0.1
+    )
+    assert all(e.is_set() for e in start_events)
+    release.set()
+    result = await task
+    assert set(result) == {"units", "categories", "pictures", "stat_labels"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeout(monkeypatch, caplog):
+    captured = {}
+
+    class DummyResponse:
+        async def __aenter__(self):
+            raise asyncio.TimeoutError
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def raise_for_status(self):
+            pass
+
+    class DummySession:
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url):
+            return DummyResponse()
+
+    monkeypatch.setattr(
+        "cogs.wcr.utils.aiohttp.ClientSession",
+        lambda *args, **kwargs: DummySession(*args, **kwargs),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = await fetch_wcr_data("http://test")
+
+    assert isinstance(captured["timeout"], aiohttp.ClientTimeout)
+    assert captured["timeout"].total == 10
+    assert result["units"] == {}
+    assert any("Timeout" in r.message for r in caplog.records)


### PR DESCRIPTION
## Zusammenfassung
- paralleler Abruf der WCR-Endpunkte über `asyncio.gather`
- 10 s Timeout für HTTP-Anfragen hinzufügen
- Fehlerbehandlung für Timeouts ergänzen
- Test für parallelen Abruf und Timeout
- README um Hinweis auf Timeout ergänzt

## Tests
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a040ead40832f9c40a8d1b785b70c