### PR TITLE
Ensure command registration syncs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
     Datei enthält ein einfaches Mapping `{name: syntax}`. Die Emoji-Namen müssen
     mit den Angaben in `data/wcr/faction_meta.json` übereinstimmen.
 - Alle Slash-Commands werden **guild-basiert** registriert und nur für die Haupt-Guild synchronisiert.
-- Zur Vereinfachung der Registrierung stellt `utils.setup_helpers.register_cog_and_group` eine Hilfsfunktion bereit.
+- Zur Vereinfachung der Registrierung stellt `utils.setup_helpers.register_cog_and_group` eine Hilfsfunktion bereit,
+  die nach dem Hinzufügen der Gruppe automatisch `bot.tree.sync` für die Haupt-Guild ausführt.
 
 Persistente Daten liegen in `data/pers/` und sollten nicht ins Repository aufgenommen werden.
 

--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -24,6 +24,11 @@ async def test_quiz_setup_uses_main_guild(monkeypatch, patch_logged_task, bot):
 
     monkeypatch.setattr(bot.tree, "add_command", fake_add)
 
+    async def fake_sync(*, guild=None):
+        pass
+
+    monkeypatch.setattr(bot.tree, "sync", fake_sync)
+
     await quiz.setup(bot)
 
     assert called == [(quiz_group, bot.main_guild)]
@@ -40,6 +45,11 @@ async def test_champion_setup_uses_main_guild(monkeypatch, bot, patch_logged_tas
         called.append((cmd, guild))
 
     monkeypatch.setattr(bot.tree, "add_command", fake_add)
+
+    async def fake_sync(*, guild=None):
+        pass
+
+    monkeypatch.setattr(bot.tree, "sync", fake_sync)
 
     await champion.setup(bot)
 
@@ -69,6 +79,11 @@ async def test_wcr_setup_uses_main_guild(monkeypatch, bot):
 
     monkeypatch.setattr(wcr, "register_cog_and_group", fake_register)
 
+    async def fake_sync(*, guild=None):
+        pass
+
+    monkeypatch.setattr(bot.tree, "sync", fake_sync)
+
     called = []
     await wcr.setup(bot)
 
@@ -83,6 +98,11 @@ async def test_ptcgp_setup_uses_main_guild(monkeypatch, bot):
         called.append((cmd, guild))
 
     monkeypatch.setattr(bot.tree, "add_command", fake_add)
+
+    async def fake_sync(*, guild=None):
+        pass
+
+    monkeypatch.setattr(bot.tree, "sync", fake_sync)
 
     await ptcgp.setup(bot)
 

--- a/tests/general/test_setup_helpers.py
+++ b/tests/general/test_setup_helpers.py
@@ -1,0 +1,32 @@
+import pytest
+from discord import app_commands
+from discord.ext import commands
+
+from utils.setup_helpers import register_cog_and_group
+
+
+class DummyCog(commands.Cog):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_register_cog_and_group_sync(monkeypatch, bot):
+    called = []
+
+    async def fake_add_cog(cog):
+        called.append("add_cog")
+
+    def fake_add_command(cmd, *, guild=None):
+        called.append((cmd.name, guild))
+
+    async def fake_sync(*, guild=None):
+        called.append(("sync", guild))
+
+    monkeypatch.setattr(bot, "add_cog", fake_add_cog)
+    monkeypatch.setattr(bot.tree, "add_command", fake_add_command)
+    monkeypatch.setattr(bot.tree, "sync", fake_sync)
+
+    group = app_commands.Group(name="dummy", description="x")
+    await register_cog_and_group(bot, DummyCog, group)
+
+    assert ("sync", bot.main_guild) in called

--- a/tests/quiz/test_quiz_setup.py
+++ b/tests/quiz/test_quiz_setup.py
@@ -15,6 +15,11 @@ async def test_quiz_setup_registers_cog_and_commands(
     bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
     bot.quiz_data = {}
 
+    async def fake_sync(*, guild=None):
+        pass
+
+    monkeypatch.setattr(bot.tree, "sync", fake_sync)
+
     await quiz.setup(bot)
 
     assert bot.get_cog("QuizCog") is not None

--- a/utils/setup_helpers.py
+++ b/utils/setup_helpers.py
@@ -8,3 +8,4 @@ async def register_cog_and_group(
     """Fügt ein Cog hinzu und registriert eine Slash-Command-Gruppe für die Haupt-Guild."""
     await bot.add_cog(cog_cls(bot))
     bot.tree.add_command(slash_group, guild=bot.main_guild)
+    await bot.tree.sync(guild=bot.main_guild)


### PR DESCRIPTION
## Summary
- sync command tree when registering command groups
- update tests for new sync behavior
- test helper function to ensure `tree.sync` is called
- document sync behavior in README

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files "*.py")`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6fe13654832fb4c8338ee2e0d7f6