### PR TITLE
Remove unused pictures test data

### DIFF
--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -55,7 +55,6 @@ async def test_wcr_setup_uses_main_guild(monkeypatch, bot):
         return {
             "units": [],
             "locals": {"en": {"units": []}},
-            "pictures": {},
             "categories": {},
             "stat_labels": {},
         }

--- a/tests/quiz/test_load_quiz_config.py
+++ b/tests/quiz/test_load_quiz_config.py
@@ -17,7 +17,7 @@ class DummyBot:
                 },
                 "languages": ["de"],
             },
-            "wcr": {"units": [], "pictures": {}, "locals": {"de": {}, "en": {}}},
+            "wcr": {"units": [], "locals": {"de": {}, "en": {}}},
         }
 
 


### PR DESCRIPTION
## Summary
- drop `pictures` dict from DummyBot in quiz config tests
- remove `pictures` field from WCR setup fixture

## Testing
- `python -m py_compile tests/quiz/test_load_quiz_config.py`
- `python -m py_compile tests/general/test_cogs_setup.py`
- `black . --check`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a7158949c832f8a5c44726b75aba6