### PR TITLE
Handle missing WCR localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ WCR_IMAGE_BASE=https://www.method.gg
 PTCGP_SKIP_SSL_VERIFY=0
 ```
 
+Ohne eine gesetzte `WCR_API_URL` wird das WCR-Modul beim Start deaktiviert.
+
 Beim ersten Start werden persistente Daten unter `data/pers/` angelegt (Punktedatenbank, Quiz-Historie etc.).
 
 ## Datenstruktur

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -30,6 +30,8 @@ class WCRCog(commands.Cog):
         if isinstance(self.units, dict) and "units" in self.units:
             self.units = self.units["units"]
         self.languages = wcr_data.get("locals", {})
+        if not self.languages:
+            raise ValueError("WCR localization data missing")
         self.categories = wcr_data.get("categories", {})
         self.stat_labels = wcr_data.get("stat_labels", {})
 

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -529,3 +529,11 @@ async def test_cmd_duel_unknown_mini(wcr_data):
     assert msg["content"] == "Eines der Minis wurde nicht gefunden."
     assert msg["ephemeral"] is False
     cog.cog_unload()
+
+
+def test_init_without_localization(caplog):
+    bot = DummyBot({})
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError) as exc:
+            WCRCog(bot)
+    assert "localization data" in str(exc.value)


### PR DESCRIPTION
## Summary
- raise a clear `ValueError` when `WCR` localization data is missing
- extend test coverage for this case
- document that `WCR_API_URL` is required to enable the WCR module

## Testing
- `black . --check`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a745dad2c832f801732a3229349e4