### PR TITLE
Raise setup errors in WCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - Alle Slash-Commands werden **guild-basiert** registriert und nur für die Haupt-Guild synchronisiert.
 - Zur Vereinfachung der Registrierung stellt `utils.setup_helpers.register_cog_and_group` eine Hilfsfunktion bereit,
   die nach dem Hinzufügen der Gruppe automatisch `bot.tree.sync` für die Haupt-Guild ausführt.
-
+  Tritt dabei ein Fehler auf, wird er geloggt und erneut geworfen, sodass ein missglückter Start sofort sichtbar ist.
 Persistente Daten liegen in `data/pers/` und sollten nicht ins Repository aufgenommen werden.
 
 ---

--- a/cogs/wcr/__init__.py
+++ b/cogs/wcr/__init__.py
@@ -19,3 +19,4 @@ async def setup(bot: discord.ext.commands.Bot):
         logger.info("[WCRCog] Cog und Slash-Command-Gruppe erfolgreich registriert.")
     except Exception as e:
         logger.error(f"[WCRCog] Fehler beim Setup: {e}", exc_info=True)
+        raise

--- a/tests/general/test_cogs_setup.py
+++ b/tests/general/test_cogs_setup.py
@@ -106,3 +106,14 @@ async def test_ptcgp_setup_uses_main_guild(monkeypatch, bot):
     await ptcgp.setup(bot)
 
     assert called == [(ptcgp_group, bot.main_guild)]
+
+
+@pytest.mark.asyncio
+async def test_wcr_setup_raises_on_error(monkeypatch, bot):
+    async def fake_register(*args, **kwargs):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(wcr, "register_cog_and_group", fake_register)
+
+    with pytest.raises(RuntimeError):
+        await wcr.setup(bot)


### PR DESCRIPTION
## Summary
- re-raise exceptions in `cogs/wcr/__init__.py`
- test that errors during setup propagate
- document that setup failures surface in the logs

## Testing
- `black .`
- `python -m py_compile cogs/wcr/__init__.py tests/general/test_cogs_setup.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a73b34834832f9b5bf2b7757a1c2f