### PR TITLE
Implement English fallback for WCR data

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
   - Bilder werden relativ zu ``WCR_IMAGE_BASE`` aufgel\u00f6st.
   - Die API stellt nur ``units`` und ``categories`` bereit. IDs sind dabei Strings.
   - Beim Abrufen dieser Daten wird ein Timeout von 10 Sekunden verwendet.
+  - Wenn deutsche Texte fehlen, greift das Modul automatisch auf die englischen
+    Daten zurück.
   - Die Fragevorlagen liegen unter `data/quiz/templates/wcr.json`.
   - Beim Start erzeugt `_export_emojis` automatisch `data/emojis.json`; diese
     Datei enthält ein einfaches Mapping `{name: syntax}`. Die Emoji-Namen müssen

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -734,7 +734,10 @@ class WCRCog(commands.Cog):
     def _prepare_traits_field(self, unit_data, lang, stat_labels):
         """Return a field for trait display if traits exist."""
         traits_ids = unit_data.get("trait_ids", [])
-        trait_lookup = self.lang_category_lookup.get(lang, {}).get("traits", {})
+        trait_lookup = (
+            self.lang_category_lookup.get(lang)
+            or self.lang_category_lookup.get("en", {})
+        ).get("traits", {})
         names = [trait_lookup[i]["name"] for i in traits_ids if i in trait_lookup]
         if not names:
             return None
@@ -749,7 +752,7 @@ class WCRCog(commands.Cog):
             unit_id, lang, self.languages
         )
 
-        stat_labels = self.stat_labels.get(lang, {})
+        stat_labels = self.stat_labels.get(lang) or self.stat_labels.get("en", {})
         factions = unit_data.get("faction_ids") or [unit_data.get("faction_id")]
         factions = [str(f) for f in factions if f is not None]
         primary_faction = factions[0] if factions else None

--- a/cogs/wcr/helpers.py
+++ b/cogs/wcr/helpers.py
@@ -31,8 +31,11 @@ def build_category_lookup(categories: dict) -> dict:
 
 
 def get_text_data(unit_id: str, lang: str, languages: dict) -> tuple[str, str, list]:
-    """Return name, description and talents for a unit in ``lang``."""
-    texts = languages.get(lang, languages.get("de", {}))
+    """Return name, description and talents for a unit in ``lang``.
+
+    Falls ``lang`` nicht vorhanden ist, werden die englischen Daten verwendet.
+    """
+    texts = languages.get(lang) or languages.get("en", {})
     unit_text = next(
         (unit for unit in texts.get("units", []) if str(unit["id"]) == unit_id), {}
     )
@@ -75,8 +78,13 @@ def get_faction_data(faction_id: str, lang_lookup: dict) -> dict:
 def get_category_name(
     category: str, category_id: str, lang: str, lang_lookup: dict
 ) -> str:
-    """Gibt den lokalisierten Namen eines Kategorie-Eintrags zurück."""
-    item = lang_lookup.get(lang, {}).get(category, {}).get(str(category_id))
+    """Gibt den lokalisierten Namen eines Kategorie-Eintrags zurück.
+
+    Ist ``lang`` nicht verfügbar, wird auf Englisch zurückgegriffen.
+    """
+    item = lang_lookup.get(lang, {}).get(category, {}).get(
+        str(category_id)
+    ) or lang_lookup.get("en", {}).get(category, {}).get(str(category_id))
     if item:
         return item.get("name", "Unbekannt")
     return "Unbekannt"

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -165,6 +165,25 @@ def test_build_mini_embed_combines_factions(wcr_data):
     cog.cog_unload()
 
 
+def test_build_mini_embed_fallback_to_en(wcr_data):
+    wcr_data["stat_labels"].pop("de")
+    wcr_data["locals"].pop("de")
+    for items in wcr_data["categories"].values():
+        for item in items:
+            item["names"].pop("de", None)
+
+    bot = DummyBot(wcr_data)
+    cog = WCRCog(bot)
+    units = bot.data["wcr"]["units"]
+    if isinstance(units, dict) and "units" in units:
+        units = units["units"]
+    unit = next(u for u in units if u["id"] == "1")
+    embed, _ = cog.build_mini_embed(unit["id"], unit, "de")
+    assert "Abomination" in embed.title
+    assert any("Cost" in f.name for f in embed.fields)
+    cog.cog_unload()
+
+
 def test_category_lookups_created(wcr_data):
     bot = DummyBot(wcr_data)
     cog = WCRCog(bot)

--- a/tests/wcr/test_wcr_helpers.py
+++ b/tests/wcr/test_wcr_helpers.py
@@ -34,6 +34,14 @@ def test_get_text_data_unknown(languages):
     assert talents == []
 
 
+def test_get_text_data_fallback_to_en(languages):
+    en_data = languages["en"]
+    del languages["de"]
+    name, desc, _ = helpers.get_text_data("1", "de", languages)
+    assert name == en_data["units"][0]["name"]
+    assert desc == en_data["units"][0]["description"]
+
+
 def test_get_pose_url_known(wcr_data):
     unit = wcr_data["units"][0]
     url = helpers.get_pose_url(unit)
@@ -69,6 +77,14 @@ def test_get_category_name_known(lang_lookup):
 def test_get_category_name_unknown(lang_lookup):
     name = helpers.get_category_name("factions", 9999, "de", lang_lookup)
     assert name == "Unbekannt"
+
+
+def test_get_category_name_fallback_to_en(categories):
+    for item in categories["factions"]:
+        item["names"].pop("de", None)
+    lang_lookup = helpers.build_category_lookup(categories)
+    name = helpers.get_category_name("factions", 1, "de", lang_lookup)
+    assert name == "Undead"
 
 
 def test_get_faction_data_known(lang_lookup):


### PR DESCRIPTION
## Summary
- ensure WCR helpers fall back to English texts and categories
- use fallback in cog for stat labels and trait names
- document fallback behaviour in README
- cover fallbacks with new tests

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a76922cf8832fbd945d489bbd38c8