### PR TITLE
Add champion DB path via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ WCR_API_URL=https://wcr-api.up.railway.app
 WCR_IMAGE_BASE=https://www.method.gg
 # Optional: Ignoriert Zertifikatsfehler der PTCGP-API
 PTCGP_SKIP_SSL_VERIFY=0
+# Optional: Pfad zur Champion-Datenbank
+CHAMPION_DB_PATH=data/pers/champion/points.db

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ WCR_API_URL=https://wcr-api.up.railway.app
 WCR_IMAGE_BASE=https://www.method.gg
 # Bei Zertifikatsproblemen kann die Überprüfung für die PTCGP-API deaktiviert werden
 PTCGP_SKIP_SSL_VERIFY=0
+# Optional: Pfad zur Champion-Datenbank
+CHAMPION_DB_PATH=data/pers/champion/points.db
 ```
 
 Ohne eine gesetzte `WCR_API_URL` wird das WCR-Modul beim Start deaktiviert.
@@ -150,7 +152,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Cogs** trennen Funktionsbereiche sauber: `quiz`, `champion`, `wcr`.
 - **Zentrale Daten** werden im `setup_hook` geladen (`bot.data`) und allen Cogs bereitgestellt.
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
-- **Champion-System** speichert Punkte in SQLite und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
+- **Champion-System** speichert Punkte in SQLite (Pfad über `CHAMPION_DB_PATH` anpassbar) und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
 - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
   - Bilder werden relativ zu ``WCR_IMAGE_BASE`` aufgel\u00f6st.

--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -3,6 +3,7 @@ import asyncio
 from dataclasses import dataclass
 from discord.ext import commands
 from typing import Optional, List
+import os
 
 from log_setup import get_logger
 from utils.managed_cog import ManagedTaskCog
@@ -20,11 +21,15 @@ class ChampionRole:
 
 class ChampionCog(ManagedTaskCog):
     def __init__(self, bot: commands.Bot) -> None:
-        """Initialisiert das Cog und lädt die Rollenkonfiguration."""
+        """Initialisiert das Cog und lädt die Rollenkonfiguration.
+
+        Der Pfad zur Punkte-Datenbank kann \u00fcber die Environment-Variable
+        ``CHAMPION_DB_PATH`` angepasst werden.
+        """
         super().__init__()
         self.bot = bot
 
-        db_path = "data/pers/champion/points.db"
+        db_path = os.getenv("CHAMPION_DB_PATH", "data/pers/champion/points.db")
         self.data = ChampionData(db_path)
 
         self.roles: List[ChampionRole] = self._load_roles_config()

--- a/tests/champion/test_db_env_path.py
+++ b/tests/champion/test_db_env_path.py
@@ -1,0 +1,27 @@
+import pytest
+import cogs.champion.cog as champion_cog_mod
+import log_setup
+from cogs.champion.cog import ChampionCog
+
+
+class DummyBot:
+    def __init__(self):
+        self.data = {"champion": {"roles": []}}
+        self.main_guild = None
+        self.guilds = []
+
+
+@pytest.mark.asyncio
+async def test_env_db_path(monkeypatch, patch_logged_task, tmp_path):
+    path = tmp_path / "custom.db"
+    monkeypatch.setenv("CHAMPION_DB_PATH", str(path))
+    patch_logged_task(champion_cog_mod, log_setup)
+
+    bot = DummyBot()
+    cog = ChampionCog(bot)
+
+    assert cog.data.db_path == str(path)
+
+    cog.cog_unload()
+    await cog.data.close()
+    await cog.wait_closed()


### PR DESCRIPTION
## Summary
- make champion DB path configurable via `CHAMPION_DB_PATH`
- document new env var in README and `.env.example`
- test that the environment variable overrides the default path

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a87a874f4832fb0655705f3d3fa48