### PR TITLE
Fix champion role selection by id only

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Cogs** trennen Funktionsbereiche sauber: `quiz`, `champion`, `wcr`.
 - **Zentrale Daten** werden im `setup_hook` geladen (`bot.data`) und allen Cogs bereitgestellt.
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
-- **Champion-System** speichert Punkte in SQLite (Pfad über `CHAMPION_DB_PATH` anpassbar) und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag).
+- **Champion-System** speichert Punkte in SQLite (Pfad über `CHAMPION_DB_PATH` anpassbar) und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag). Fehlt eine definierte ID, wird keine gleichnamige Rolle verwendet und es erscheint ein Hinweis im Log.
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
 - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
   - Bilder werden relativ zu ``WCR_IMAGE_BASE`` aufgel\u00f6st.

--- a/cogs/champion/cog.py
+++ b/cogs/champion/cog.py
@@ -86,7 +86,11 @@ class ChampionCog(ManagedTaskCog):
                 self.update_queue.task_done()
 
     async def _apply_champion_role(self, user_id_str: str, score: int) -> None:
-        """Vergibt anhand der Punkte die passende Champion-Rolle."""
+        """Vergibt anhand der Punkte die passende Champion-Rolle.
+
+        Existiert die im Config definierte Rollen-ID nicht, wird keine Rolle
+        vergeben und ein Hinweis geloggt.
+        """
         # Zugriff auf Guild NUR noch über self.bot.main_guild (Zentral, wie in bot.py gesetzt)
         guild = self.bot.main_guild
         if not isinstance(guild, discord.Guild):
@@ -118,8 +122,10 @@ class ChampionCog(ManagedTaskCog):
             if role.id in current_role_ids and role != target_role:
                 role_obj = guild.get_role(role.id)
                 if role_obj is None:
-                    role_obj = discord.utils.get(guild.roles, name=role.name)
-                if role_obj:
+                    logger.warning(
+                        f"[ChampionCog] Rolle '{role.name}' mit ID {role.id} existiert nicht."
+                    )
+                else:
                     roles_to_remove.append(role_obj)
 
         if roles_to_remove:
@@ -140,8 +146,10 @@ class ChampionCog(ManagedTaskCog):
 
         target_role_obj = guild.get_role(target_role.id)
         if target_role_obj is None:
-            target_role_obj = discord.utils.get(guild.roles, name=target_role.name)
-        if target_role_obj:
+            logger.warning(
+                f"[ChampionCog] Rolle '{target_role.name}' mit ID {target_role.id} existiert nicht."
+            )
+        else:
             try:
                 await member.add_roles(target_role_obj)
                 logger.info(
@@ -156,10 +164,6 @@ class ChampionCog(ManagedTaskCog):
                     f"[ChampionCog] Fehler beim Hinzufügen der Rolle: {e}",
                     exc_info=True,
                 )
-        else:
-            logger.warning(
-                f"[ChampionCog] Rolle '{target_role.name}' existiert nicht in Discord."
-            )
 
     def cog_unload(self):
         """Beendet Tasks und schließt die Datenbankverbindung."""


### PR DESCRIPTION
## Summary
- remove name fallback when selecting champion roles
- log a warning if a configured role ID doesn't exist
- test champion role adding when ID is missing
- document role ID handling in README

## Testing
- `black .`
- `python -m py_compile cogs/champion/cog.py tests/champion/test_champion_cog.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a898a4cdc832fbab64c6f1ee9dcae