### PR TITLE
Limit champion update queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 - Refaktor: `cmd_duel` nutzt nun `_compute_duel_outcome` und die neue `DuelOutcome`-Dataclass.
+- ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);
+  beim Füllen wird ein ``QueueFull``-Fehler geloggt.
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
 - **Champion-System** speichert Punkte in SQLite (Pfad über `CHAMPION_DB_PATH` anpassbar) und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag). Fehlt eine definierte ID, wird keine gleichnamige Rolle verwendet und es erscheint ein Hinweis im Log.
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
+- Die Warteschlange für Rollen-Updates fasst standardmäßig 1000 Einträge. Bei
+  Überschreitung wird ein ``QueueFull``-Fehler geloggt.
 - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
   - Bilder werden relativ zu ``WCR_IMAGE_BASE`` aufgel\u00f6st.
   - Die API stellt nur ``units`` und ``categories`` bereit. IDs sind dabei Strings.


### PR DESCRIPTION
## Summary
- cap ChampionCog.update_queue capacity to 1000 items
- log an error when the queue is full
- document queue limit in README
- add changelog entry
- test QueueFull logging

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a8be9a5b4832fa2d37a92d987895b