### PR TITLE
Improve ChampionCog error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 - Verbessertes Shutdown-Verhalten: ChampionCog schließt jetzt zuerst die Datenbank und stoppt danach alle Tasks.
+- ChampionCog.update_user_score loggt jetzt Datenbankfehler und wirft einen
+  ``RuntimeError`` bei Fehlschlagen des Datenbankzugriffs.
 ## Unreleased
 - Refaktor: `cmd_duel` nutzt nun `_compute_duel_outcome` und die neue `DuelOutcome`-Dataclass.
 - ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);

--- a/tests/champion/test_update_errors.py
+++ b/tests/champion/test_update_errors.py
@@ -1,0 +1,39 @@
+import logging
+import pytest
+import aiosqlite
+
+import cogs.champion.cog as champion_cog_mod
+from cogs.champion.cog import ChampionCog
+from cogs.champion.data import ChampionData
+import log_setup
+
+
+class DummyBot:
+    def __init__(self):
+        self.data = {"champion": {"roles": []}}
+        self.main_guild = None
+        self.guilds = []
+
+
+@pytest.mark.asyncio
+async def test_update_user_score_db_error(
+    monkeypatch, patch_logged_task, tmp_path, caplog
+):
+    patch_logged_task(champion_cog_mod, log_setup)
+    bot = DummyBot()
+    cog = ChampionCog(bot)
+    cog.data = ChampionData(str(tmp_path / "points.db"))
+
+    async def fail(*args, **kwargs):
+        raise aiosqlite.Error("boom")
+
+    monkeypatch.setattr(cog.data, "add_delta", fail)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            await cog.update_user_score(1, 1, "test")
+
+    assert any("DB-Fehler" in r.message for r in caplog.records)
+
+    await cog.cog_unload()
+    await cog.wait_closed()


### PR DESCRIPTION
## Summary
- handle database errors in `ChampionCog.update_user_score`
- document raised exception in docstring
- add regression test for logging and error propagation
- document behaviour in changelog

## Testing
- `black . --quiet`
- `flake8 .`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_685a8f7aef74832f91aeb2923a86ff61