### PR TITLE
Fix negative champion totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Verbessertes Shutdown-Verhalten: ChampionCog schließt jetzt zuerst die Datenbank und stoppt danach alle Tasks.
 - ChampionCog.update_user_score loggt jetzt Datenbankfehler und wirft einen
   ``RuntimeError`` bei Fehlschlagen des Datenbankzugriffs.
+- ChampionData.add_delta begrenzt Punktestände auf mindestens 0 und protokolliert Vorher- und Nachher-Wert.
 ## Unreleased
 - Refaktor: `cmd_duel` nutzt nun `_compute_duel_outcome` und die neue `DuelOutcome`-Dataclass.
 - ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Zentrale Daten** werden im `setup_hook` geladen (`bot.data`) und allen Cogs bereitgestellt.
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
 - **Champion-System** speichert Punkte in SQLite (Pfad über `CHAMPION_DB_PATH` anpassbar) und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag). Fehlt eine definierte ID, wird keine gleichnamige Rolle verwendet und es erscheint ein Hinweis im Log.
+- Punktestände können nicht negativ werden; zu hohe Abzüge setzen sie automatisch auf 0.
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
 - Die Warteschlange für Rollen-Updates fasst standardmäßig 1000 Einträge. Bei
   Überschreitung wird ein ``QueueFull``-Fehler geloggt.

--- a/tests/champion/test_champion_data.py
+++ b/tests/champion/test_champion_data.py
@@ -24,6 +24,21 @@ async def test_add_and_get_total(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_subtract_more_than_total_sets_zero(tmp_path):
+    db_path = tmp_path / "neg" / "points.db"
+    data = ChampionData(str(db_path))
+
+    await data.add_delta("user1", 5, "init")
+    total = await data.add_delta("user1", -10, "remove")
+
+    assert total == 0
+
+    await data.close()
+    db_path.unlink()
+    assert not db_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_get_history(tmp_path):
     db_path = tmp_path / "history" / "points.db"
     data = ChampionData(str(db_path))


### PR DESCRIPTION
## Summary
- keep champion totals from going negative
- clarify champion system behaviour in docs
- note new behaviour in CHANGELOG
- test negative delta edge case

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a90f9be8c832f9abc1d05550bcf4b