### PR TITLE
Implement fallback when WCR locals missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Refaktor: `cmd_duel` nutzt nun `_compute_duel_outcome` und die neue
   `DuelOutcome`-Dataclass.
 - ChampionData.add_delta begrenzt Punktestände auf mindestens 0 und protokolliert Vorher- und Nachher-Wert.
+- WCRCog fällt nun auf englische Texte zurück, wenn ``locals`` fehlen.
 ## Unreleased
 - Refaktor: `cmd_duel` nutzt nun `_compute_duel_outcome` und die neue `DuelOutcome`-Dataclass.
 - ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
   - Beim Abrufen dieser Daten wird ein Timeout von 10 Sekunden verwendet.
   - Wenn deutsche Texte fehlen, greift das Modul automatisch auf die englischen
     Daten zurück.
+  - Fehlen die Lokalisierungsdaten komplett (``locals``), wird aus den
+    ``units`` ein englischer Fallback erzeugt.
   - Die Fragevorlagen liegen unter `data/quiz/templates/wcr.json`.
   - Geladene Daten werden in `data/pers/wcr_cache.json` zwischengespeichert.
     Die Gültigkeitsdauer lässt sich über ``WCR_CACHE_TTL`` steuern.

--- a/cogs/wcr/cog.py
+++ b/cogs/wcr/cog.py
@@ -23,7 +23,7 @@ class DuelOutcome:
 
 class WCRCog(commands.Cog):
     def __init__(self, bot) -> None:
-        """Cog providing Warcraft Rumble helper commands."""
+        """Cog für Warcraft Rumble Befehle mit automatischem Fallback."""
         self.bot = bot
 
         wcr_data = bot.data.get("wcr") or {}
@@ -39,7 +39,17 @@ class WCRCog(commands.Cog):
             self.units = self.units["units"]
         self.languages = wcr_data.get("locals", {})
         if not self.languages:
-            raise ValueError("WCR localization data missing")
+            logger.warning(
+                "[WCRCog] Keine Lokalisierung gefunden, fallback auf Englisch."
+            )
+            en_units = []
+            for unit in self.units:
+                text = unit.get("texts", {}).get("en")
+                if text:
+                    entry = {"id": unit.get("id")}
+                    entry.update(text)
+                    en_units.append(entry)
+            self.languages = {"en": {"units": en_units}}
         self.categories = wcr_data.get("categories", {})
         self.stat_labels = wcr_data.get("stat_labels", {})
         self.faction_combinations = wcr_data.get("faction_combinations", {})

--- a/tests/wcr/test_wcr_cog.py
+++ b/tests/wcr/test_wcr_cog.py
@@ -544,9 +544,12 @@ async def test_cmd_duel_unknown_mini(wcr_data):
     cog.cog_unload()
 
 
-def test_init_without_localization(caplog):
-    bot = DummyBot({})
+def test_init_without_localization_fallback(wcr_data, caplog):
+    wcr_data["locals"] = {}
+    bot = DummyBot(wcr_data)
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(ValueError) as exc:
-            WCRCog(bot)
-    assert "localization data" in str(exc.value)
+        cog = WCRCog(bot)
+
+    assert "fallback" in caplog.records[0].message.lower()
+    assert "en" in cog.languages
+    cog.cog_unload()


### PR DESCRIPTION
## Summary
- handle missing `locals` in `WCRCog.__init__` by creating an English fallback
- note the new behaviour in README and CHANGELOG
- update tests for fallback logic

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a94064978832f9dc4eb858dfedc61