### PR TITLE
Remove discord import in champion init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);
   beim Füllen wird ein ``QueueFull``-Fehler geloggt.
 
+- Bereinigt: `cogs/champion/__init__.py` verwendet nun `commands.Bot` und entfernt den Import von `discord`.

--- a/cogs/champion/__init__.py
+++ b/cogs/champion/__init__.py
@@ -1,4 +1,4 @@
-import discord
+from discord.ext import commands
 
 from log_setup import get_logger
 
@@ -8,7 +8,7 @@ from utils.setup_helpers import register_cog_and_group
 logger = get_logger(__name__)
 
 
-async def setup(bot: discord.ext.commands.Bot):
+async def setup(bot: commands.Bot):
     """Registriert Cog und Slash-Befehle für das Champion-System."""
     try:
         from .slash_commands import champion_group, syncroles


### PR DESCRIPTION
## Summary
- clean up unused import
- use `commands.Bot` directly
- document cleanup

## Testing
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a944451c8832f95c2e9a90fb35b7a