### PR TITLE
Handle full update queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - WCRCog fällt nun auf englische Texte zurück, wenn ``locals`` fehlen.
 ## Unreleased
 - Refaktor: `cmd_duel` nutzt nun `_compute_duel_outcome` und die neue `DuelOutcome`-Dataclass.
-- ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);
-  beim Füllen wird ein ``QueueFull``-Fehler geloggt.
+ - ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);
+    beim Füllen wird nun ein ``RuntimeError`` ausgelöst.
 
 - Bereinigt: `cogs/champion/__init__.py` verwendet nun `commands.Bot` und entfernt den Import von `discord`.

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Champion-System** speichert Punkte in SQLite (Pfad über `CHAMPION_DB_PATH` anpassbar) und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag). Fehlt eine definierte ID, wird keine gleichnamige Rolle verwendet und es erscheint ein Hinweis im Log.
 - Punktestände können nicht negativ werden; zu hohe Abzüge setzen sie automatisch auf 0.
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
-- Die Warteschlange für Rollen-Updates fasst standardmäßig 1000 Einträge. Bei
-  Überschreitung wird ein ``QueueFull``-Fehler geloggt.
+  - Die Warteschlange für Rollen-Updates fasst standardmäßig 1000 Einträge. Bei
+  Überschreitung wird nun ein ``RuntimeError`` ausgelöst.
 - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.
   - Bilder werden relativ zu ``WCR_IMAGE_BASE`` aufgel\u00f6st.
   - Die API stellt nur ``units`` und ``categories`` bereit. IDs sind dabei Strings.


### PR DESCRIPTION
## Summary
- always create ChampionCog.update_queue with maxsize=1000
- raise RuntimeError when queue is full
- update README and CHANGELOG
- test queue full behaviour

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9848a2e8832f98d3d971393ba9da