### PR TITLE
Handle CancelledError in worker task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 - Verbessertes Shutdown-Verhalten: ChampionCog schließt jetzt zuerst die Datenbank und stoppt danach alle Tasks.
+- Das ChampionCog-Arbeitertask fängt nun ``CancelledError`` ab und markiert
+  angefangene Queue-Einträge sauber als erledigt.
 - ChampionCog.update_user_score loggt jetzt Datenbankfehler und wirft einen
   ``RuntimeError`` bei Fehlschlagen des Datenbankzugriffs.
 - Neues JSON-Cache-System für WCR-Daten (``WCR_CACHE_TTL`` konfiguriert die


### PR DESCRIPTION
## Summary
- improve ChampionCog worker shutdown on CancelledError
- add regression test for task shutdown
- ensure queue test awaits cog_unload
- document improved shutdown handling in CHANGELOG

## Testing
- `black . --check`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9aca87f4832f9d91a20193f98d3c