### PR TITLE
Improve task cancellation handling and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,7 @@
 
 - Bereinigt: `cogs/champion/__init__.py` verwendet nun `commands.Bot` und entfernt den Import von `discord`.
 - Dokumentation erweitert: Beispiele für `/wcr`-Befehle und Hinweise zum neuen WCR-Cache.
+- ``create_logged_task`` ignoriert nun ``asyncio.CancelledError``.
+- ``QuizCog.cog_unload`` löscht das Attribut ``quiz_cog`` am Bot.
+- Tests verwenden ein sessionweites ``event_loop``-Fixture.
+- Neue Tests für ``QuestionManager.ask_question`` und ``QuestionRestorer.repost_question``.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ flake8       # Linting
 pytest -q    # Test Suite
 ```
 
-Neue Features benötigen passende Tests. Die Fixtures in `tests/conftest.py` stellen Umgebungsvariablen bereit und bieten `patch_logged_task`, das `create_logged_task` nun global ersetzt. Ebenfalls sorgt `auto_stop_views` dafür, dass in Tests erstellte `discord.ui.View`-Instanzen automatisch gestoppt werden. Das neue Fixture `assert_no_tasks` prüft zudem, ob nach jedem Test noch asyncio-Tasks laufen und schlägt sonst fehl.
+Neue Features benötigen passende Tests. Die Fixtures in `tests/conftest.py` stellen Umgebungsvariablen bereit und bieten `patch_logged_task`, das `create_logged_task` nun global ersetzt. Ebenfalls sorgt `auto_stop_views` dafür, dass in Tests erstellte `discord.ui.View`-Instanzen automatisch gestoppt werden. Das neue Fixture `assert_no_tasks` prüft zudem, ob nach jedem Test noch asyncio-Tasks laufen und schlägt sonst fehl. Zusätzlich stellt `tests/conftest.py` ein sessionweites ``event_loop``-Fixture bereit, damit alle Async-Tests denselben Loop nutzen und am Ende sauber schließen.
 
 Pull Requests sind willkommen! Bitte halte dich an den bestehenden Codestyle (PEP8, formatiert mit *Black*) und prüfe vor dem Commit, dass `flake8` und `pytest` grün sind.
 

--- a/cogs/quiz/cog.py
+++ b/cogs/quiz/cog.py
@@ -89,4 +89,7 @@ class QuizCog(ManagedTaskCog):
         self.tracker.register_message(message)
 
     def cog_unload(self) -> None:
+        """Remove background tasks and clear ``bot.quiz_cog`` reference."""
         super().cog_unload()
+        if hasattr(self.bot, "quiz_cog"):
+            del self.bot.quiz_cog

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,16 @@ from pathlib import Path
 
 pytest_plugins = ["pytest_asyncio"]
 
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create a dedicated event loop for the entire test session."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    loop.close()
+
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)

--- a/tests/general/test_logged_task.py
+++ b/tests/general/test_logged_task.py
@@ -1,0 +1,18 @@
+import asyncio
+import logging
+import pytest
+
+import log_setup
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_is_ignored(caplog):
+    async def coro():
+        await asyncio.sleep(0)
+
+    task = log_setup.create_logged_task(coro(), logging.getLogger(__name__))
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert not caplog.records

--- a/tests/quiz/test_question_manager.py
+++ b/tests/quiz/test_question_manager.py
@@ -1,0 +1,113 @@
+import datetime
+import pytest
+import discord
+
+from cogs.quiz.question_manager import QuestionManager
+from cogs.quiz.quiz_config import QuizAreaConfig
+
+
+class DummyGenerator:
+    def __init__(self, question=None, use_default=True):
+        if question is None and use_default:
+            self.question = {"frage": "f", "antwort": "a", "category": "c"}
+        else:
+            self.question = question
+
+    async def generate(self, area, language="de"):
+        return self.question
+
+
+class DummyChannel:
+    def __init__(self):
+        self.id = 1
+        self.sent = []
+
+    async def send(self, *, embed=None, view=None):
+        self.sent.append((embed, view))
+        msg = discord.Object(id=42)
+        return msg
+
+
+class DummyTracker:
+    def __init__(self):
+        self.reset_called = False
+
+    def reset(self, cid):
+        self.reset_called = True
+
+
+class DummyState:
+    def __init__(self):
+        self.recorded = []
+
+    async def set_active_question(self, area, qinfo):
+        self.recorded.append((area, qinfo))
+
+
+class DummyCloser:
+    async def auto_close(self, area, delay):
+        pass
+
+
+class DummyCog:
+    def __init__(self, bot):
+        self.bot = bot
+        self.tracker = DummyTracker()
+        self.state = DummyState()
+        self.closer = DummyCloser()
+        self.current_questions = {}
+        self.answered_users = {"area": set()}
+        self.awaiting_activity = {}
+
+        def _track_task(coro):
+            coro.close()
+
+        self._track_task = _track_task
+
+
+class DummyBot:
+    def __init__(self, channel, generator):
+        self.quiz_data = {
+            "area": QuizAreaConfig(
+                channel_id=channel.id, question_generator=generator, language="de"
+            )
+        }
+        self.main_guild = 0
+        self.main_guild_id = 0
+        self.data = {}
+        self._channel = channel
+
+    def get_channel(self, cid):
+        return self._channel
+
+
+@pytest.mark.asyncio
+async def test_ask_question_posts_and_tracks(monkeypatch):
+    channel = DummyChannel()
+    generator = DummyGenerator()
+    bot = DummyBot(channel, generator)
+    cog = DummyCog(bot)
+    manager = QuestionManager(cog)
+
+    end_time = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
+    await manager.ask_question("area", end_time)
+
+    assert cog.current_questions["area"].message_id == 42
+    assert cog.tracker.reset_called
+    assert cog.state.recorded
+    assert channel.sent
+
+
+@pytest.mark.asyncio
+async def test_ask_question_no_question():
+    channel = DummyChannel()
+    generator = DummyGenerator(question=None, use_default=False)
+    bot = DummyBot(channel, generator)
+    cog = DummyCog(bot)
+    manager = QuestionManager(cog)
+
+    end_time = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
+    await manager.ask_question("area", end_time)
+
+    assert "area" not in cog.current_questions
+    assert not channel.sent

--- a/tests/quiz/test_question_restorer.py
+++ b/tests/quiz/test_question_restorer.py
@@ -1,0 +1,105 @@
+import datetime
+import pytest
+
+import cogs.quiz.question_restorer as restorer_mod
+from cogs.quiz.question_state import QuestionInfo
+from cogs.quiz.quiz_config import QuizAreaConfig
+
+
+class DummyBot:
+    def __init__(self, channel):
+        self._channel = channel
+        self.quiz_data = {
+            "area": QuizAreaConfig(channel_id=channel.id, question_state=None)
+        }
+        self.quiz_cog = type(
+            "QuizCog",
+            (),
+            {
+                "current_questions": {},
+                "answered_users": {"area": set()},
+                "closer": type("Closer", (), {"auto_close": lambda *a, **k: None})(),
+            },
+        )()
+
+    async def fetch_channel(self, cid):
+        return self._channel
+
+
+class DummyMessage:
+    def __init__(self, mid):
+        self.id = mid
+        self.embeds = []
+        self.edits = []
+
+    async def edit(self, *, embed=None, view=None):
+        self.edits.append((embed, view))
+
+
+class DummyChannel:
+    def __init__(self, message=None, raise_notfound=False):
+        self.id = 1
+        self.message = message or DummyMessage(42)
+        self.raise_notfound = raise_notfound
+
+    async def fetch_message(self, mid):
+        if self.raise_notfound:
+            raise restorer_mod.discord.NotFound(None, None)
+        return self.message
+
+
+class DummyState:
+    def __init__(self):
+        self.cleared = []
+
+    async def clear_active_question(self, area):
+        self.cleared.append(area)
+
+    def get_active_question(self, area):
+        return None
+
+
+def make_restorer(channel):
+    bot = DummyBot(channel)
+
+    def create_task(coro):
+        return None
+
+    state = DummyState()
+    r = restorer_mod.QuestionRestorer(bot, state, create_task)
+    return r, bot, state
+
+
+@pytest.mark.asyncio
+async def test_repost_question_success():
+    channel = DummyChannel()
+    rest, bot, state = make_restorer(channel)
+    qinfo = QuestionInfo(
+        message_id=42,
+        end_time=datetime.datetime.utcnow() + datetime.timedelta(seconds=1),
+        answers=["a"],
+        frage="f",
+        category="c",
+    )
+
+    await rest.repost_question("area", qinfo)
+
+    assert bot.quiz_cog.current_questions["area"].message_id == 42
+    assert channel.message.edits
+
+
+@pytest.mark.asyncio
+async def test_repost_question_missing_message():
+    channel = DummyChannel(raise_notfound=True)
+    rest, bot, state = make_restorer(channel)
+    qinfo = QuestionInfo(
+        message_id=42,
+        end_time=datetime.datetime.utcnow(),
+        answers=["a"],
+        frage="f",
+        category="c",
+    )
+
+    await rest.repost_question("area", qinfo)
+
+    assert state.cleared == ["area"]

--- a/tests/quiz/test_quiz_cog_unload.py
+++ b/tests/quiz/test_quiz_cog_unload.py
@@ -1,0 +1,45 @@
+import pytest
+
+import cogs.quiz.cog as quiz_cog_mod
+import cogs.quiz.message_tracker as msg_mod
+import log_setup
+from cogs.quiz.quiz_config import QuizAreaConfig
+
+
+class DummyState:
+    async def set_schedule(self, *args):
+        pass
+
+    def get_schedule(self, area):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_cog_unload_removes_attribute(monkeypatch, patch_logged_task, bot):
+    patch_logged_task(log_setup, msg_mod)
+
+    async def dummy_restore(self):
+        return None
+
+    async def dummy_init(self):
+        return None
+
+    async def dummy_run(self):
+        return None
+
+    monkeypatch.setattr(quiz_cog_mod.QuestionRestorer, "restore_all", dummy_restore)
+    monkeypatch.setattr(quiz_cog_mod.MessageTracker, "initialize", dummy_init)
+    monkeypatch.setattr(quiz_cog_mod.QuizScheduler, "run", dummy_run)
+
+    bot.quiz_data = {
+        "area": QuizAreaConfig(channel_id=1, active=False, question_state=DummyState())
+    }
+    bot.data = {"quiz": {"questions": {"de": {}}, "languages": ["de"]}}
+
+    cog = quiz_cog_mod.QuizCog(bot)
+    assert hasattr(bot, "quiz_cog")
+
+    cog.cog_unload()
+    await cog.wait_closed()
+
+    assert not hasattr(bot, "quiz_cog")


### PR DESCRIPTION
## Summary
- ignore `CancelledError` in `create_logged_task`
- remove `quiz_cog` reference when unloading `QuizCog`
- add session-wide `event_loop` fixture
- document new behavior and fixtures
- add tests for logged task cancellation, question manager, question restorer and cog unload

## Testing
- `black .`
- `python -m py_compile log_setup.py cogs/quiz/cog.py tests/general/test_logged_task.py tests/quiz/test_quiz_cog_unload.py tests/quiz/test_question_manager.py tests/quiz/test_question_restorer.py tests/conftest.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae4f275f8832fb87c9c9e5fead8bd