### PR TITLE
Improve champion cog shutdown and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-- Verbessertes Shutdown-Verhalten: ChampionCog schließt jetzt zuerst die Datenbank und stoppt danach alle Tasks.
+- Verbessertes Shutdown-Verhalten: ChampionCog schließt die Datenbank, stoppt alle Tasks und wartet auf deren Abschluss.
+- Champion-Mod-Befehle verlangen nun positive Punktwerte.
 - WCR-Cog aufgeteilt: Namensauflösung und Embed-Aufbau sind nun in eigenen Modulen. Fehlerbehandlung und Tests wurden erweitert.
 - ChampionCog.update_user_score loggt jetzt Datenbankfehler und wirft einen
   ``RuntimeError`` bei Fehlschlagen des Datenbankzugriffs.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Befehle mit dem Hinweis *Mod* sind nur für Nutzer mit dem Recht `Manage Server`
 - **Quiz-Subsystem** nutzt einen `QuestionGenerator` (statisch & dynamisch), `QuestionStateManager` für Persistenz und einen Scheduler für automatische Fragen. Der nächste geplante Zeitpunkt wird gespeichert, sodass laufende Fenster nach einem Neustart fortgeführt werden können.
 - **Champion-System** speichert Punkte in SQLite (Pfad über `CHAMPION_DB_PATH` anpassbar) und vergibt Rollen gemäß `data/champion/roles.json` (Rollen-ID und Schwelle pro Eintrag). Fehlt eine definierte ID, wird keine gleichnamige Rolle verwendet und es erscheint ein Hinweis im Log.
 - Punktestände können nicht negativ werden; zu hohe Abzüge setzen sie automatisch auf 0.
+- Die Mod-Befehle `give`, `remove` und `set` akzeptieren nur noch positive Werte.
 - Beim Entladen des Champion-Cogs wird die Datenbankverbindung sauber geschlossen.
+- Beim Entladen wird nun auch auf alle Hintergrund-Tasks gewartet.
   - Die Warteschlange für Rollen-Updates fasst standardmäßig 1000 Einträge. Bei
   Überschreitung wird nun ein ``RuntimeError`` ausgelöst.
 - **WCR-Modul** bezieht seine Daten über die in ``WCR_API_URL`` angegebene API und nutzt sie für Autocomplete sowie dynamische Fragen.

--- a/cogs/champion/slash_commands.py
+++ b/cogs/champion/slash_commands.py
@@ -21,13 +21,22 @@ champion_group = app_commands.Group(
     grund="Begründung",
 )
 async def give(
-    interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str
+    interaction: discord.Interaction,
+    user: discord.Member,
+    punkte: app_commands.Range[int, 1],
+    grund: str,
 ):
     """Verleiht einem Nutzer Punkte."""
 
     logger.info(
         f"/champion give by {interaction.user} -> {user} ({punkte} Punkte, Grund: {grund})"
     )
+
+    if punkte < 1:
+        await interaction.response.send_message(
+            "❌ Punkte müssen mindestens 1 betragen.", ephemeral=True
+        )
+        return
 
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     new_total = await cog.update_user_score(user.id, punkte, grund)
@@ -46,13 +55,22 @@ async def give(
     grund="Begründung",
 )
 async def remove(
-    interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str
+    interaction: discord.Interaction,
+    user: discord.Member,
+    punkte: app_commands.Range[int, 1],
+    grund: str,
 ):
     """Zieht einem Nutzer Punkte ab."""
 
     logger.info(
         f"/champion remove by {interaction.user} -> {user} ({punkte} Punkte, Grund: {grund})"
     )
+
+    if punkte < 1:
+        await interaction.response.send_message(
+            "❌ Punkte müssen mindestens 1 betragen.", ephemeral=True
+        )
+        return
 
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     new_total = await cog.update_user_score(user.id, -punkte, grund)
@@ -73,13 +91,22 @@ async def remove(
     grund="Begründung",
 )
 async def set_points(
-    interaction: discord.Interaction, user: discord.Member, punkte: int, grund: str
+    interaction: discord.Interaction,
+    user: discord.Member,
+    punkte: app_commands.Range[int, 1],
+    grund: str,
 ):
     """Setzt die Punktzahl eines Nutzers direkt."""
 
     logger.info(
         f"/champion set by {interaction.user} -> {user} ({punkte} Punkte, Grund: {grund})"
     )
+
+    if punkte < 1:
+        await interaction.response.send_message(
+            "❌ Punktzahl muss mindestens 1 betragen.", ephemeral=True
+        )
+        return
 
     cog: ChampionCog = interaction.client.get_cog("ChampionCog")
     old_total = await cog.data.get_total(str(user.id))

--- a/tests/champion/test_champion_cog.py
+++ b/tests/champion/test_champion_cog.py
@@ -98,8 +98,6 @@ async def test_update_user_score_saves_and_calls(
     assert total == 5
     assert called == [("123", 5)]
     await cog.cog_unload()
-    await asyncio.gather(*tasks, return_exceptions=True)
-    await cog.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -132,7 +130,6 @@ async def test_updates_processed_in_order(monkeypatch, patch_logged_task, tmp_pa
 
     assert order == [("123", 1), ("124", 2), ("125", 3)]
     await cog.cog_unload()
-    await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -171,7 +168,6 @@ async def test_apply_role_removes_when_below_threshold(monkeypatch, patch_logged
     assert member.removed == [silver]
     assert member.added == []
     await cog.cog_unload()
-    await cog.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -234,8 +230,6 @@ async def test_worker_cancelled_on_unload(monkeypatch, patch_logged_task):
     cog = ChampionCog(bot)
 
     await cog.cog_unload()
-    await asyncio.gather(*tasks, return_exceptions=True)
-    await cog.wait_closed()
 
     assert cog.worker_task.cancelled()
 
@@ -268,4 +262,3 @@ async def test_queue_raises_when_full(monkeypatch, patch_logged_task, caplog):
     assert any("update_queue voll" in r.message for r in caplog.records)
 
     await cog.cog_unload()
-    await cog.wait_closed()

--- a/tests/champion/test_mod_ephemeral.py
+++ b/tests/champion/test_mod_ephemeral.py
@@ -1,6 +1,12 @@
 import pytest
 
-from cogs.champion.slash_commands import give, history, score
+from cogs.champion.slash_commands import (
+    give,
+    history,
+    remove,
+    score,
+    set_points,
+)
 
 
 class DummyBot:
@@ -72,6 +78,23 @@ async def test_give_sends_ephemeral_message():
 
 
 @pytest.mark.asyncio
+async def test_give_rejects_non_positive():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+    target = DummyMember(1)
+
+    await give.callback(inter, target, 0, "reason")
+
+    assert cog.updated == []
+    assert inter.response.messages
+    msg, ephemeral = inter.response.messages[0]
+    assert "mindestens 1" in msg
+    assert ephemeral is True
+
+
+@pytest.mark.asyncio
 async def test_history_empty_is_ephemeral():
     bot = DummyBot()
     cog = DummyCog()
@@ -87,6 +110,23 @@ async def test_history_empty_is_ephemeral():
 
 
 @pytest.mark.asyncio
+async def test_remove_rejects_non_positive():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+    target = DummyMember(2)
+
+    await remove.callback(inter, target, -1, "reason")
+
+    assert cog.updated == []
+    assert inter.response.messages
+    msg, ephemeral = inter.response.messages[0]
+    assert "mindestens 1" in msg
+    assert ephemeral is True
+
+
+@pytest.mark.asyncio
 async def test_score_is_ephemeral():
     bot = DummyBot()
     cog = DummyCog()
@@ -97,4 +137,21 @@ async def test_score_is_ephemeral():
 
     assert inter.response.messages
     _, ephemeral = inter.response.messages[0]
+    assert ephemeral is True
+
+
+@pytest.mark.asyncio
+async def test_set_points_rejects_non_positive():
+    bot = DummyBot()
+    cog = DummyCog()
+    bot._cog = cog
+    inter = DummyInteraction(bot)
+    target = DummyMember(3)
+
+    await set_points.callback(inter, target, 0, "reason")
+
+    assert cog.updated == []
+    assert inter.response.messages
+    msg, ephemeral = inter.response.messages[0]
+    assert "mindestens 1" in msg
     assert ephemeral is True


### PR DESCRIPTION
## Summary
- ensure `_worker` gracefully handles cancelled tasks
- wait for background tasks in `ChampionCog.cog_unload`
- restrict mod commands to positive values and reject invalid input
- document new behaviour and validation
- adjust unit tests for new shutdown and add validation tests

## Testing
- `python -m py_compile cogs/champion/cog.py cogs/champion/slash_commands.py tests/champion/test_champion_cog.py tests/champion/test_mod_ephemeral.py`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae51e2534832fa528518eca8eaf38