### PR TITLE
Fix Snyk check when secrets missing

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,10 @@
 name: Security Audit
 
 on:
+  push:
+    paths:
+      - 'requirements*.txt'
+      - '.github/workflows/**'
   pull_request:
     paths:
       - 'requirements*.txt'
@@ -50,10 +54,10 @@ jobs:
       - name: Generate SBOM
         run: cyclonedx-bom -o sbom.xml
       - name: Snyk Test
-        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
-        run: snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && env.SNYK_TOKEN != '' }}
+        run: snyk test
       - name: Upload SBOM
         if: always()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@
 - README folgt nun der globalen Struktur und `.env.example` dokumentiert alle
   benötigten Variablen.
 - CI: Skip Snyk test in forked PRs to prevent missing-secret auth errors.
+- Security-Workflow wird nun auch bei Push-Events ausgeführt und überspringt den Snyk-Test, wenn kein `SNYK_TOKEN` vorhanden ist.


### PR DESCRIPTION
## Summary
- trigger security workflow on push and pull_request
- skip Snyk scan when `SNYK_TOKEN` isn't provided using env-based check
- note workflow change in changelog

## Testing
- `pre-commit run --files .github/workflows/security.yml CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d267c9a10832f83923e05886b2116