### PR TITLE
WoW-Duo: Level-Partner-Matchmaking im Forum wow-duo

### DIFF
--- a/src/lotus_bot/cogs/wow/__init__.py
+++ b/src/lotus_bot/cogs/wow/__init__.py
@@ -4,6 +4,7 @@ from lotus_bot.log_setup import get_logger
 from lotus_bot.utils.setup_helpers import register_cog_and_group
 
 from .cog import WoWCog
+from .duo_cog import DuoCog
 
 logger = get_logger(__name__)
 
@@ -15,6 +16,11 @@ async def setup(bot: commands.Bot):
 
         await register_cog_and_group(bot, WoWCog, wow_group)
         logger.info("[WoWCog] Cog and slash command group registered successfully.")
+
+        from .duo_slash import duo_group
+
+        await register_cog_and_group(bot, DuoCog, duo_group)
+        logger.info("[DuoCog] Cog and slash command group registered successfully.")
     except Exception as e:
         logger.error(f"[WoWCog] Error during setup: {e}", exc_info=True)
         raise

--- a/src/lotus_bot/cogs/wow/cog.py
+++ b/src/lotus_bot/cogs/wow/cog.py
@@ -1285,6 +1285,9 @@ class WoWCog(ManagedTaskCog):
                 milestone.member.character_key, milestone.level
             )
             await self._award_claimed_milestone_points(milestone)
+            # Duo hook AFTER record_milestone so the "both partners reached it"
+            # check sees the just-recorded event (timing-independent).
+            await self._notify_duo_milestone(milestone)
         for death in activity.deaths:
             await self.data.record_death(death.member.character_key)
             # Auto-release the dead char's claim so the owner can claim a
@@ -1299,6 +1302,9 @@ class WoWCog(ManagedTaskCog):
                 # Losing the last claimed char must cost the guild role; the
                 # hourly reconcile would catch it too, but do it immediately.
                 await self.reconcile_guild_role_for(claim.discord_user_id)
+            # Duo hook: memorial in the team thread if the fallen char was in
+            # an active team. Independent of the claim (team keeps the key).
+            await self._notify_duo_death(death)
         for event in activity.recipe_events or []:
             await self.data.mark_recipe_learning_announced(
                 event.character_key, event.spell_id
@@ -1316,6 +1322,32 @@ class WoWCog(ManagedTaskCog):
             await self._award_skill_milestone_points(event)
         # Cooldowns are read-only in the digest — no DB write needed here.
         await self._retry_unawarded_pending_events()
+
+    def _duo_cog(self):
+        get_cog = getattr(self.bot, "get_cog", None)
+        return get_cog("DuoCog") if get_cog else None
+
+    async def _notify_duo_milestone(self, milestone: Milestone) -> None:
+        """Fire-and-forget: let the Duo cog celebrate a team level-milestone."""
+        duo = self._duo_cog()
+        if duo is None or not hasattr(duo, "on_character_milestone"):
+            return
+        try:
+            await duo.on_character_milestone(
+                milestone.member.character_key, milestone.level
+            )
+        except Exception as exc:  # pragma: no cover - defensive integration logging
+            logger.warning("[WoWCog] Duo-Milestone-Hook fehlgeschlagen: %s", exc)
+
+    async def _notify_duo_death(self, death: DeathEvent) -> None:
+        """Fire-and-forget: let the Duo cog post a memorial for a fallen partner."""
+        duo = self._duo_cog()
+        if duo is None or not hasattr(duo, "on_character_death"):
+            return
+        try:
+            await duo.on_character_death(death.member.character_key, death.member.level)
+        except Exception as exc:  # pragma: no cover - defensive integration logging
+            logger.warning("[WoWCog] Duo-Death-Hook fehlgeschlagen: %s", exc)
 
     async def _retry_unawarded_pending_events(self) -> None:
         """Re-fund events that were announced but never landed Champion points.

--- a/src/lotus_bot/cogs/wow/duo_cog.py
+++ b/src/lotus_bot/cogs/wow/duo_cog.py
@@ -1,0 +1,1219 @@
+"""WoW-Duo: Level-Partner-Matchmaking im Forum-Channel ``wow-duo``.
+
+Konzept
+-------
+* Ein angepinnter Hub-Post mit Buttons (Partner suchen / Mein Status / Hilfe).
+* Wer sucht, bekommt einen **öffentlichen Forum-Post** ("🔍 … sucht
+  Level-Partner") mit einem *Mit mir leveln*-Button — das Schwarze Brett.
+* Klickt jemand den Button, geht eine Anfrage an den Sucher; nimmt der an,
+  entsteht ein **Team-Post** ("🤝 Team Phoenix"), beide werden hinzugefügt und
+  die beiden Such-Posts verschwinden.
+* Der Team-Post ist die gemeinsame Reise: automatische Level-Meilenstein-Posts,
+  Champion-Bonus wenn beide einen Meilenstein erreichen, und — Hardcore — ein
+  Memorial wenn ein Partner fällt, mit der Option weiterzumachen oder das Team
+  ehrenvoll aufzulösen.
+
+Kopplung
+--------
+Der Cog liest Claims/Roster über ``WoWCog.data`` und wird von ``WoWCog`` bei
+Tod/Meilenstein über :meth:`on_character_death` / :meth:`on_character_milestone`
+aufgerufen — dasselbe ``get_cog``-Muster, mit dem ``WoWCog`` den ``ChampionCog``
+anspricht.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import discord
+from discord.ext import commands
+
+from lotus_bot.log_setup import get_logger
+from lotus_bot.utils.managed_cog import ManagedTaskCog
+
+from .cog import CLASS_NAMES_DE, HORDE_RED, RACE_NAMES_DE
+from .duo_data import DuoData, DuoSignup, DuoTeam
+from .duo_logic import (
+    TIME_WINDOWS,
+    decode_windows,
+    encode_windows,
+    format_windows,
+    overlap_keys,
+    pick_team_name,
+    rank_candidates,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .cog import WoWCog
+
+logger = get_logger(__name__)
+
+DUO_FORUM_CHANNEL_ID = 1526376290129678406
+
+# Forum tag names the bot manages. Created on startup if missing (needs
+# Manage-Channels); everything degrades gracefully to "no tag" if it can't.
+TAG_SEARCHING = "🔍 Sucht Partner"
+TAG_ACTIVE = "🟢 Aktiv"
+TAG_MOURNING = "🕯️ In Trauer"
+TAG_DISBANDED = "🕯️ Aufgelöst"
+
+# Bonus Champion points to BOTH partners when the team reaches a milestone
+# together. On top of the solo milestone points the WoW cog already awards.
+DUO_MILESTONE_BONUS = {30: 3, 40: 6, 50: 12, 60: 30}
+
+HUB_TEXT = (
+    "# 🤝 Zusammen leveln\n"
+    "Niemand muss allein leveln. Such dir einen Partner — mehr Spaß, viel "
+    "sicherer, und ihr schreibt eure Hardcore-Geschichte gemeinsam.\n\n"
+    "**So geht's:**\n"
+    "1. **Partner suchen** — Char wählen, Zeiten anklicken, fertig. Dein "
+    "Suchpost erscheint hier im Forum.\n"
+    "2. Findest du unten jemand Passenden, klick **🤝 Mit mir leveln** in "
+    "seinem Post.\n"
+    "3. Nimmt er an, macht der Bot euch ein **Team** mit eigenem Thread — "
+    "Termine, Screenshots, eure Reise.\n\n"
+    "Nur für Black-Lotus-Member. Horde, deutsch, Hardcore. 🪷"
+)
+HUB_HELP_TEXT = (
+    "**❓ Hilfe – Zusammen leveln**\n\n"
+    "**Partner suchen** — wähle einen deiner geclaimten Chars und deine "
+    "typischen Spielzeiten. Der Bot stellt dich aufs Board und zeigt dir "
+    "direkt, wer zeitlich zu dir passt.\n\n"
+    "**Mit mir leveln** — in einem fremden Suchpost startest du damit eine "
+    "Anfrage. Der andere muss zustimmen, dann entsteht euer Team.\n\n"
+    "**Mein Status** — zeigt, ob du suchst oder in einem Team bist, mit "
+    "Buttons zum Bearbeiten, Zurückziehen oder Auflösen.\n\n"
+    "**Im Team** — der Bot postet automatisch, wenn ihr Meilensteine "
+    "erreicht (Level 30/40/50/60) und vergibt Bonus-Champion-Punkte, wenn "
+    "**beide** dort ankommen. Fällt ein Partner, bekommt ihr ein Memorial "
+    "und könnt entscheiden, ob ihr weitermacht.\n\n"
+    "**Meinen Char wechseln** — im Team-Thread, falls du rerollst oder nach "
+    "einem Tod mit einem neuen Char weiterziehst."
+)
+
+
+def _class_name(class_id: int | None) -> str:
+    return CLASS_NAMES_DE.get(class_id or 0, "?")
+
+
+def _race_name(race_id: int | None) -> str:
+    return RACE_NAMES_DE.get(race_id or 0, "")
+
+
+class DuoCog(ManagedTaskCog):
+    """Level-Partner-Matchmaking für Black Lotus."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        super().__init__()
+        self.bot = bot
+        self.data = DuoData("data/pers/wow/duo.db")
+        self.forum_channel_id = DUO_FORUM_CHANNEL_ID
+        self._tags: dict[str, discord.ForumTag] = {}
+        self.create_task(self._startup())
+        if hasattr(self.bot, "add_view"):
+            self.bot.add_view(DuoHubView(self))
+            self.bot.add_view(DuoSearchPostView(self))
+            self.bot.add_view(DuoTeamPostView(self))
+
+    # ---- infrastructure ----
+
+    @property
+    def wow(self) -> "WoWCog | None":
+        get_cog = getattr(self.bot, "get_cog", None)
+        return get_cog("WoWCog") if get_cog else None
+
+    def forum(self) -> discord.ForumChannel | None:
+        channel = self.bot.get_channel(self.forum_channel_id)
+        return channel if isinstance(channel, discord.ForumChannel) else None
+
+    async def _startup(self) -> None:
+        await self.bot.wait_until_ready()
+        try:
+            await self.publish_hub()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("[DuoCog] Hub-Publish beim Start fehlgeschlagen: %s", exc)
+
+    async def _ensure_tags(self, forum: discord.ForumChannel) -> None:
+        """Resolve (and create if missing) the managed forum tags."""
+        wanted = [TAG_SEARCHING, TAG_ACTIVE, TAG_MOURNING, TAG_DISBANDED]
+        by_name = {tag.name: tag for tag in forum.available_tags}
+        self._tags = {name: by_name[name] for name in wanted if name in by_name}
+        missing = [name for name in wanted if name not in by_name]
+        for name in missing:
+            try:
+                tag = await forum.create_tag(name=name)
+                self._tags[name] = tag
+            except (discord.Forbidden, discord.HTTPException) as exc:
+                logger.info("[DuoCog] Forum-Tag '%s' nicht anlegbar: %s", name, exc)
+
+    def _tag(self, name: str) -> list[discord.ForumTag]:
+        tag = self._tags.get(name)
+        return [tag] if tag else []
+
+    async def publish_hub(self) -> None:
+        """Create or refresh the pinned hub post in the forum."""
+        forum = self.forum()
+        if forum is None:
+            logger.warning(
+                "[DuoCog] Forum-Channel %s nicht gefunden.", self.forum_channel_id
+            )
+            return
+        await self._ensure_tags(forum)
+        view = DuoHubView(self)
+        hub_id = await self.data.get_setting("hub_thread_id")
+        if hub_id:
+            try:
+                thread = self.bot.get_channel(
+                    int(hub_id)
+                ) or await self.bot.fetch_channel(int(hub_id))
+                if isinstance(thread, discord.Thread):
+                    await thread.get_partial_message(int(hub_id)).edit(
+                        content=HUB_TEXT, view=view
+                    )
+                    await self._try_pin(thread)
+                    return
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                logger.info("[DuoCog] Bestehender Hub-Post nicht editierbar — neu.")
+        created = await forum.create_thread(
+            name="📖 Zusammen leveln – Start hier", content=HUB_TEXT
+        )
+        # create_thread can't attach a view directly (discord.py 2.7); the
+        # persistent buttons go onto the starter message afterwards.
+        await created.message.edit(view=view)
+        await self.data.set_setting("hub_thread_id", str(created.thread.id))
+        await self._try_pin(created.thread)
+
+    async def _try_pin(self, thread: discord.Thread) -> None:
+        try:
+            await thread.edit(pinned=True)
+        except (discord.Forbidden, discord.HTTPException, TypeError):
+            pass
+
+    # ---- character helpers ----
+
+    async def _living_claim_chars(
+        self, user_id: int
+    ) -> list[tuple[str, str, int, int | None]]:
+        """Return ``(character_key, name, level, class_id)`` for the user's
+        currently-alive, in-roster claimed characters."""
+        wow = self.wow
+        if wow is None:
+            return []
+        claims = await wow.data.claims_for_user(user_id)
+        snapshot = await wow.data.get_snapshot()
+        result: list[tuple[str, str, int, int | None]] = []
+        for claim in claims:
+            member = snapshot.get(claim.character_key)
+            if member is None or member.is_ghost:
+                continue
+            result.append(
+                (
+                    claim.character_key,
+                    claim.character_name,
+                    member.level,
+                    member.class_id,
+                )
+            )
+        result.sort(key=lambda item: item[1].casefold())
+        return result
+
+    async def _char_descriptor(self, character_key: str, fallback_name: str) -> str:
+        """Human line for a character from the live roster snapshot."""
+        wow = self.wow
+        if wow is None:
+            return f"**{fallback_name}**"
+        snapshot = await wow.data.get_snapshot()
+        member = snapshot.get(character_key)
+        if member is None:
+            return f"**{fallback_name}**"
+        bits = [f"Level {member.level}"]
+        race = _race_name(member.race_id)
+        klass = _class_name(member.class_id)
+        if race:
+            bits.append(race)
+        if klass != "?":
+            bits.append(klass)
+        return f"**{member.name}** ({', '.join(bits)})"
+
+    async def _char_level(self, character_key: str) -> int:
+        wow = self.wow
+        if wow is None:
+            return 0
+        snapshot = await wow.data.get_snapshot()
+        member = snapshot.get(character_key)
+        return member.level if member else 0
+
+    # ---- hub button entry points ----
+
+    async def open_search(self, interaction: discord.Interaction) -> None:
+        team = await self.data.active_team_for_user(interaction.user.id)
+        if team is not None:
+            await interaction.response.send_message(
+                f"Du bist schon in **{team.name}** "
+                f"({_thread_mention(team.thread_id)}). Löse das Team zuerst über "
+                "**Mein Status** auf, wenn du neu suchen willst.",
+                ephemeral=True,
+            )
+            return
+        chars = await self._living_claim_chars(interaction.user.id)
+        if not chars:
+            await interaction.response.send_message(
+                "Du musst zuerst einen lebenden Black-Lotus-Char claimen "
+                "(WoW-Hub → **Deine Chars**), bevor du einen Partner suchst.",
+                ephemeral=True,
+            )
+            return
+        view = DuoSearchComposeView(self, interaction.user.id, chars)
+        await interaction.response.send_message(
+            "**Partner-Suche erstellen** — wähle deinen Char und deine "
+            "typischen Spielzeiten, dann **Auf's Board**.",
+            view=view,
+            ephemeral=True,
+        )
+
+    async def open_status(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            **await self._status_payload(interaction.user.id), ephemeral=True
+        )
+
+    async def open_help(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(HUB_HELP_TEXT, ephemeral=True)
+
+    async def _status_payload(self, user_id: int) -> dict:
+        team = await self.data.active_team_for_user(user_id)
+        if team is not None:
+            members = await self.data.team_members(team.team_id)
+            lines = [
+                f"🤝 Du bist in **{team.name}** ({_thread_mention(team.thread_id)})."
+            ]
+            for member in members:
+                who = (
+                    "Du"
+                    if member.discord_user_id == user_id
+                    else f"<@{member.discord_user_id}>"
+                )
+                lines.append(
+                    f"• {who}: {await self._char_descriptor(member.character_key, member.character_name)}"
+                )
+            return {"content": "\n".join(lines), "view": DuoStatusTeamView(self, team)}
+        signup = await self.data.get_signup(user_id)
+        if signup is not None:
+            windows = format_windows(decode_windows(signup.time_windows))
+            content = (
+                f"🔍 Du suchst mit "
+                f"{await self._char_descriptor(signup.character_key, signup.character_name)}.\n"
+                f"**Zeiten:** {windows}\n"
+                f"**Post:** {_thread_mention(signup.post_id)}"
+            )
+            return {"content": content, "view": DuoStatusSearchView(self)}
+        return {
+            "content": "Du suchst gerade nicht und bist in keinem Team.",
+            "view": DuoStatusIdleView(self),
+        }
+
+    # ---- search publishing ----
+
+    async def publish_search(
+        self, interaction: discord.Interaction, character_key: str, windows: list[str]
+    ) -> None:
+        wow = self.wow
+        forum = self.forum()
+        if wow is None or forum is None:
+            await interaction.response.edit_message(
+                content="❌ System aktuell nicht verfügbar.", view=None
+            )
+            return
+        claim = await wow.data.get_claim(character_key)
+        if claim is None or claim.discord_user_id != interaction.user.id:
+            await interaction.response.edit_message(
+                content="❌ Dieser Char gehört dir nicht (mehr).", view=None
+            )
+            return
+
+        encoded = encode_windows(windows)
+        # Replace any previous open search + its forum post.
+        old = await self.data.get_signup(interaction.user.id)
+        if old is not None and old.post_id:
+            await self._delete_post(old.post_id)
+
+        await self.data.upsert_signup(
+            interaction.user.id,
+            character_key,
+            claim.character_name,
+            claim.realm_slug,
+            encoded,
+            None,
+        )
+        await interaction.response.edit_message(
+            content="✅ Deine Suche wird erstellt …", view=None
+        )
+
+        descriptor = await self._char_descriptor(character_key, claim.character_name)
+        body = (
+            f"**{claim.character_name} sucht einen Level-Partner!**\n\n"
+            f"• {descriptor}\n"
+            f"• **Zeiten:** {format_windows(decode_windows(encoded))}\n"
+            f"• Gesucht von <@{interaction.user.id}>\n\n"
+            "Passt zu dir? Klick **🤝 Mit mir leveln** — der Rest geht von allein."
+        )
+        created = await forum.create_thread(
+            name=f"🔍 {claim.character_name} sucht Level-Partner",
+            content=body,
+            applied_tags=self._tag(TAG_SEARCHING),
+        )
+        await created.message.edit(view=DuoSearchPostView(self))
+        await self.data.set_signup_post(interaction.user.id, created.thread.id)
+
+        # Light suggestion nudge: who overlaps best with the fresh searcher.
+        suggestions = await self._suggestions_for(interaction.user.id)
+        note = f"\n\n**Passt gerade zu dir:**\n{suggestions}" if suggestions else ""
+        try:
+            await interaction.edit_original_response(
+                content=(f"✅ Deine Suche ist online: {created.thread.mention}{note}")
+            )
+        except discord.HTTPException:
+            pass
+
+    async def _suggestions_for(self, user_id: int) -> str:
+        signup = await self.data.get_signup(user_id)
+        if signup is None:
+            return ""
+        my_windows = decode_windows(signup.time_windows)
+        my_level = await self._char_level(signup.character_key)
+        others = []
+        for other in await self.data.list_signups(exclude_user_id=user_id):
+            level = await self._char_level(other.character_key)
+            others.append(
+                (
+                    other.discord_user_id,
+                    other.character_name,
+                    level,
+                    decode_windows(other.time_windows),
+                )
+            )
+        ranked = rank_candidates(my_windows, my_level, others)
+        lines = []
+        for cand in ranked[:3]:
+            if cand.overlap_count == 0:
+                continue
+            shared = format_windows(cand.overlap)
+            lines.append(
+                f"• <@{cand.discord_user_id}> — **{cand.character_name}** "
+                f"(Level {cand.level}) · gemeinsam: {shared}"
+            )
+        return "\n".join(lines)
+
+    # ---- join / request / team creation ----
+
+    async def handle_join(self, interaction: discord.Interaction) -> None:
+        channel = interaction.channel
+        signup = (
+            await self.data.get_signup_by_post(channel.id)
+            if isinstance(channel, discord.Thread)
+            else None
+        )
+        if signup is None:
+            await interaction.response.send_message(
+                "Diese Suche ist nicht mehr aktiv.", ephemeral=True
+            )
+            return
+        if signup.discord_user_id == interaction.user.id:
+            await interaction.response.send_message(
+                "Das ist deine eigene Suche. 🙂", ephemeral=True
+            )
+            return
+        existing_team = await self.data.active_team_for_user(interaction.user.id)
+        if existing_team is not None:
+            await interaction.response.send_message(
+                f"Du bist schon in **{existing_team.name}**. Löse es zuerst auf.",
+                ephemeral=True,
+            )
+            return
+        my_signup = await self.data.get_signup(interaction.user.id)
+        if my_signup is not None:
+            await self._send_request(
+                interaction, signup, my_signup.character_key, my_signup.character_name
+            )
+            return
+        chars = await self._living_claim_chars(interaction.user.id)
+        if not chars:
+            await interaction.response.send_message(
+                "Du brauchst einen lebenden, geclaimten Char, um mitzuleveln.",
+                ephemeral=True,
+            )
+            return
+        view = DuoJoinCharSelectView(self, signup, chars)
+        await interaction.response.send_message(
+            f"Mit welchem Char willst du zu **{signup.character_name}**?",
+            view=view,
+            ephemeral=True,
+        )
+
+    async def _send_request(
+        self,
+        interaction: discord.Interaction,
+        owner_signup: DuoSignup,
+        requester_char_key: str,
+        requester_char_name: str,
+    ) -> None:
+        my_level = await self._char_level(requester_char_key)
+        shared = overlap_keys(
+            decode_windows(owner_signup.time_windows),
+            [],  # filled below from requester signup if present
+        )
+        req_signup = await self.data.get_signup(interaction.user.id)
+        if req_signup is not None:
+            shared = overlap_keys(
+                decode_windows(owner_signup.time_windows),
+                decode_windows(req_signup.time_windows),
+            )
+        shared_txt = (
+            f"\nGemeinsame Zeiten: **{format_windows(shared)}**" if shared else ""
+        )
+        view = DuoJoinRequestView(
+            self,
+            owner_id=owner_signup.discord_user_id,
+            requester_id=interaction.user.id,
+            requester_char_key=requester_char_key,
+            requester_char_name=requester_char_name,
+        )
+        try:
+            await interaction.channel.send(
+                content=(
+                    f"<@{owner_signup.discord_user_id}> — <@{interaction.user.id}> "
+                    f"will mit dir leveln! (**{requester_char_name}**, Level "
+                    f"{my_level}){shared_txt}\n"
+                    "Nimm an, dann macht der Bot euch ein Team."
+                ),
+                view=view,
+            )
+        except (discord.Forbidden, discord.HTTPException):
+            await interaction.response.send_message(
+                "❌ Anfrage konnte nicht gesendet werden.", ephemeral=True
+            )
+            return
+        await interaction.response.send_message(
+            f"✅ Anfrage an <@{owner_signup.discord_user_id}> gesendet.",
+            ephemeral=True,
+        )
+
+    async def accept_request(
+        self,
+        interaction: discord.Interaction,
+        owner_id: int,
+        requester_id: int,
+        requester_char_key: str,
+        requester_char_name: str,
+    ) -> None:
+        owner_signup = await self.data.get_signup(owner_id)
+        if owner_signup is None:
+            await interaction.response.edit_message(
+                content="Diese Suche ist nicht mehr aktiv.", view=None
+            )
+            return
+        if await self.data.active_team_for_user(requester_id) is not None:
+            await interaction.response.edit_message(
+                content=f"<@{requester_id}> ist bereits in einem Team.", view=None
+            )
+            return
+        if await self.data.active_team_for_user(owner_id) is not None:
+            await interaction.response.edit_message(
+                content="Du bist bereits in einem Team.", view=None
+            )
+            return
+        await interaction.response.edit_message(
+            content="✅ Angenommen! Euer Team wird erstellt …", view=None
+        )
+        await self._create_team(
+            owner_id,
+            owner_signup.character_key,
+            owner_signup.character_name,
+            requester_id,
+            requester_char_key,
+            requester_char_name,
+        )
+
+    async def _create_team(
+        self,
+        owner_id: int,
+        owner_char_key: str,
+        owner_char_name: str,
+        requester_id: int,
+        requester_char_key: str,
+        requester_char_name: str,
+    ) -> None:
+        forum = self.forum()
+        if forum is None:
+            return
+        name = pick_team_name(await self.data.used_team_names())
+        owner_line = await self._char_descriptor(owner_char_key, owner_char_name)
+        req_line = await self._char_descriptor(requester_char_key, requester_char_name)
+
+        owner_signup = await self.data.get_signup(owner_id)
+        req_signup = await self.data.get_signup(requester_id)
+        shared = overlap_keys(
+            decode_windows(owner_signup.time_windows) if owner_signup else [],
+            decode_windows(req_signup.time_windows) if req_signup else [],
+        )
+        embed = discord.Embed(
+            title=f"🤝 {name}",
+            description=(
+                "Euer gemeinsamer Weg beginnt. Viel Erfolg — und passt "
+                "aufeinander auf. 🪷"
+            ),
+            colour=HORDE_RED,
+        )
+        embed.add_field(
+            name="Partner 1", value=f"<@{owner_id}>\n{owner_line}", inline=True
+        )
+        embed.add_field(
+            name="Partner 2", value=f"<@{requester_id}>\n{req_line}", inline=True
+        )
+        if shared:
+            embed.add_field(
+                name="Gemeinsame Zeiten", value=format_windows(shared), inline=False
+            )
+        embed.set_footer(text="Meilensteine & Reise werden hier automatisch geteilt.")
+
+        created = await forum.create_thread(
+            name=f"🤝 {name}",
+            embed=embed,
+            applied_tags=self._tag(TAG_ACTIVE),
+        )
+        await created.message.edit(view=DuoTeamPostView(self))
+        thread = created.thread
+        await self.data.create_team(
+            name,
+            thread.id,
+            [
+                (owner_id, owner_char_key, owner_char_name),
+                (requester_id, requester_char_key, requester_char_name),
+            ],
+        )
+        for user_id in (owner_id, requester_id):
+            try:
+                await thread.add_user(discord.Object(id=user_id))
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+        try:
+            pin_msg = await thread.send(
+                "📌 **Haltet hier eure Termine fest** — wann geht's weiter? "
+                "Postet ruhig Screenshots, das ist eure Reise."
+            )
+            await pin_msg.pin()
+        except (discord.Forbidden, discord.HTTPException):
+            pass
+
+        # Both searchers are now paired: drop their board posts + signups.
+        for signup in (owner_signup, req_signup):
+            if signup is None:
+                continue
+            if signup.post_id:
+                await self._delete_post(signup.post_id)
+            await self.data.remove_signup(signup.discord_user_id)
+
+    # ---- status actions (edit / withdraw / disband / swap) ----
+
+    async def withdraw_search(self, interaction: discord.Interaction) -> None:
+        signup = await self.data.get_signup(interaction.user.id)
+        if signup is None:
+            await interaction.response.edit_message(
+                content="Du hast keine aktive Suche.", view=None
+            )
+            return
+        if signup.post_id:
+            await self._delete_post(signup.post_id)
+        await self.data.remove_signup(interaction.user.id)
+        await interaction.response.edit_message(
+            content="✅ Deine Suche wurde zurückgezogen.", view=None
+        )
+
+    async def disband_team_for(self, interaction: discord.Interaction) -> None:
+        team = await self.data.active_team_for_user(interaction.user.id)
+        if team is None:
+            await interaction.response.send_message(
+                "Du bist in keinem Team.", ephemeral=True
+            )
+            return
+        await self._disband(team)
+        await interaction.response.send_message(
+            f"✅ **{team.name}** wurde aufgelöst.", ephemeral=True
+        )
+
+    async def _disband(self, team: DuoTeam) -> None:
+        await self.data.disband_team(team.team_id)
+        thread = await self._fetch_thread(team.thread_id)
+        if thread is not None:
+            try:
+                await thread.send(
+                    "🕯️ Dieses Team wurde aufgelöst. Danke für die Reise."
+                )
+                await thread.edit(applied_tags=self._tag(TAG_DISBANDED), archived=True)
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+
+    async def start_char_swap(self, interaction: discord.Interaction) -> None:
+        """Team member picks a new dedicated char (reroll / after a death)."""
+        channel = interaction.channel
+        team = (
+            await self.data.get_team_by_thread(channel.id)
+            if isinstance(channel, discord.Thread)
+            else None
+        )
+        if team is None or team.status == "disbanded":
+            await interaction.response.send_message(
+                "Dieses Team ist nicht mehr aktiv.", ephemeral=True
+            )
+            return
+        members = await self.data.team_members(team.team_id)
+        if interaction.user.id not in {m.discord_user_id for m in members}:
+            await interaction.response.send_message(
+                "Nur Team-Mitglieder können das.", ephemeral=True
+            )
+            return
+        chars = await self._living_claim_chars(interaction.user.id)
+        if not chars:
+            await interaction.response.send_message(
+                "Du hast keinen lebenden, geclaimten Char zum Wechseln.",
+                ephemeral=True,
+            )
+            return
+        view = DuoSwapCharSelectView(self, team, chars)
+        await interaction.response.send_message(
+            "Welchen Char bringst du jetzt ins Team?", view=view, ephemeral=True
+        )
+
+    async def apply_char_swap(
+        self, interaction: discord.Interaction, team: DuoTeam, character_key: str
+    ) -> None:
+        wow = self.wow
+        if wow is None:
+            await interaction.response.edit_message(content="❌ Fehler.", view=None)
+            return
+        claim = await wow.data.get_claim(character_key)
+        if claim is None or claim.discord_user_id != interaction.user.id:
+            await interaction.response.edit_message(
+                content="❌ Dieser Char gehört dir nicht.", view=None
+            )
+            return
+        await self.data.swap_member_character(
+            team.team_id, interaction.user.id, character_key, claim.character_name
+        )
+        await self.data.set_team_status(team.team_id, "active")
+        await interaction.response.edit_message(
+            content=f"✅ Du ziehst jetzt mit **{claim.character_name}** weiter.",
+            view=None,
+        )
+        thread = await self._fetch_thread(team.thread_id)
+        if thread is not None:
+            descriptor = await self._char_descriptor(
+                character_key, claim.character_name
+            )
+            try:
+                await thread.send(
+                    f"🔄 <@{interaction.user.id}> zieht jetzt mit {descriptor} "
+                    f"weiter. **{team.name}** macht weiter! 💪"
+                )
+                await thread.edit(applied_tags=self._tag(TAG_ACTIVE))
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+
+    # ---- hooks called by WoWCog ----
+
+    async def on_character_death(self, character_key: str, level: int) -> None:
+        """Post a memorial in the team thread when a partner falls (HC)."""
+        try:
+            team = await self.data.active_team_by_character(character_key)
+            if team is None:
+                return
+            members = await self.data.team_members(team.team_id)
+            fallen = next(
+                (m for m in members if m.character_key == character_key), None
+            )
+            if fallen is None:
+                return
+            thread = await self._fetch_thread(team.thread_id)
+            if thread is None:
+                return
+            await self.data.set_team_status(team.team_id, "mourning")
+            survivors = [
+                m for m in members if m.discord_user_id != fallen.discord_user_id
+            ]
+            ping = " ".join(f"<@{m.discord_user_id}>" for m in members)
+            survivor_ping = (
+                " ".join(f"<@{m.discord_user_id}>" for m in survivors) or "Team"
+            )
+            embed = discord.Embed(
+                title="🕯️ Ein Partner ist gefallen",
+                description=(
+                    f"**{fallen.character_name}** ist auf Level **{level}** "
+                    f"gefallen. Hardcore vergisst nichts.\n\n"
+                    f"{survivor_ping} — ihr könnt euer Team fortführen: "
+                    f"<@{fallen.discord_user_id}> wählt über **🔄 Meinen Char "
+                    "wechseln** einen neuen Char. Oder löst **{team}** ehrenvoll "
+                    "auf.".replace("{team}", team.name)
+                ),
+                colour=HORDE_RED,
+            )
+            await thread.send(content=ping, embed=embed)
+            try:
+                await thread.edit(applied_tags=self._tag(TAG_MOURNING))
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("[DuoCog] on_character_death fehlgeschlagen: %s", exc)
+
+    async def on_character_milestone(self, character_key: str, level: int) -> None:
+        """Celebrate a level milestone in the team thread; duo bonus if both."""
+        try:
+            if level not in DUO_MILESTONE_BONUS:
+                return
+            team = await self.data.active_team_by_character(character_key)
+            if team is None:
+                return
+            thread = await self._fetch_thread(team.thread_id)
+            if thread is None:
+                return
+            members = await self.data.team_members(team.team_id)
+            reached = [
+                await self._reached_milestone(m.character_key, level) for m in members
+            ]
+            both_reached = len(members) >= 2 and all(reached)
+            if both_reached and await self.data.record_duo_milestone(
+                team.team_id, level
+            ):
+                bonus = DUO_MILESTONE_BONUS[level]
+                ping = " ".join(f"<@{m.discord_user_id}>" for m in members)
+                await thread.send(
+                    f"🎉 {ping} — **{team.name}** ist gemeinsam auf **Level "
+                    f"{level}**! Bonus: **+{bonus}** Champion-Punkte für beide. 🪷"
+                )
+                for member in members:
+                    await self._award_champion(
+                        member.discord_user_id,
+                        bonus,
+                        f"Duo-Meilenstein {team.name}: gemeinsam Level {level}",
+                    )
+            elif not both_reached:
+                fallen_behind = [m for m in members if m.character_key != character_key]
+                waiting = (
+                    " ".join(f"<@{m.discord_user_id}>" for m in fallen_behind) or ""
+                )
+                mover = next(
+                    (m for m in members if m.character_key == character_key), None
+                )
+                mover_name = mover.character_name if mover else "Ein Partner"
+                await thread.send(
+                    f"🏅 **{mover_name}** hat Level **{level}** erreicht! "
+                    f"{waiting} zieh nach — dann gibt's Bonus für beide. 💪"
+                )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("[DuoCog] on_character_milestone fehlgeschlagen: %s", exc)
+
+    async def _reached_milestone(self, character_key: str, level: int) -> bool:
+        """Whether a character has reached ``level``, timing-independent.
+
+        Prefers WoWData's recorded milestone event (authoritative, unaffected
+        by the fact that the live snapshot is only rewritten *after* the scan
+        posts). Falls back to the current snapshot level so characters that
+        were already past the milestone when they joined the team still count.
+        """
+        wow = self.wow
+        if wow is None:
+            return False
+        try:
+            if await wow.data.milestone_exists(character_key, level):
+                return True
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return await self._char_level(character_key) >= level
+
+    async def _award_champion(self, user_id: int, points: int, reason: str) -> None:
+        get_cog = getattr(self.bot, "get_cog", None)
+        champion = get_cog("ChampionCog") if get_cog else None
+        if champion is None or not hasattr(champion, "update_user_score"):
+            logger.info("[DuoCog] ChampionCog nicht verfügbar für Duo-Bonus.")
+            return
+        try:
+            await champion.update_user_score(user_id, points, reason)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("[DuoCog] Champion-Bonus fehlgeschlagen: %s", exc)
+
+    # ---- thread/post utilities ----
+
+    async def _fetch_thread(self, thread_id: int | None) -> discord.Thread | None:
+        if not thread_id:
+            return None
+        channel = self.bot.get_channel(thread_id)
+        if isinstance(channel, discord.Thread):
+            return channel
+        try:
+            fetched = await self.bot.fetch_channel(thread_id)
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            return None
+        return fetched if isinstance(fetched, discord.Thread) else None
+
+    async def _delete_post(self, thread_id: int) -> None:
+        thread = await self._fetch_thread(thread_id)
+        if thread is None:
+            return
+        try:
+            await thread.delete()
+        except (discord.Forbidden, discord.HTTPException):
+            # Fall back to archiving if we can't delete.
+            try:
+                await thread.edit(archived=True, locked=True)
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+
+
+def _thread_mention(thread_id: int | None) -> str:
+    return f"<#{thread_id}>" if thread_id else "—"
+
+
+# --------------------------------------------------------------------------- #
+#                                   Views                                      #
+# --------------------------------------------------------------------------- #
+
+
+class DuoHubView(discord.ui.View):
+    """Persistent buttons on the pinned hub post."""
+
+    def __init__(self, cog: DuoCog) -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Partner suchen",
+        style=discord.ButtonStyle.success,
+        emoji="🤝",
+        custom_id="duo_hub:search",
+    )
+    async def search(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.open_search(interaction)
+
+    @discord.ui.button(
+        label="Mein Status",
+        style=discord.ButtonStyle.secondary,
+        custom_id="duo_hub:status",
+    )
+    async def status(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.open_status(interaction)
+
+    @discord.ui.button(
+        label="Hilfe",
+        style=discord.ButtonStyle.secondary,
+        custom_id="duo_hub:help",
+    )
+    async def help(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.open_help(interaction)
+
+
+class DuoSearchPostView(discord.ui.View):
+    """Persistent 'Mit mir leveln' button on a public search post."""
+
+    def __init__(self, cog: DuoCog) -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Mit mir leveln",
+        style=discord.ButtonStyle.success,
+        emoji="🤝",
+        custom_id="duo_post:join",
+    )
+    async def join(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.handle_join(interaction)
+
+
+class DuoTeamPostView(discord.ui.View):
+    """Persistent buttons on a team post."""
+
+    def __init__(self, cog: DuoCog) -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Meinen Char wechseln",
+        style=discord.ButtonStyle.secondary,
+        emoji="🔄",
+        custom_id="duo_team:swap",
+    )
+    async def swap(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.start_char_swap(interaction)
+
+    @discord.ui.button(
+        label="Team auflösen",
+        style=discord.ButtonStyle.danger,
+        emoji="🕯️",
+        custom_id="duo_team:disband",
+    )
+    async def disband(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.disband_team_for(interaction)
+
+
+class _OwnerCheckMixin(discord.ui.View):
+    """Restrict a transient view to a single user."""
+
+    allowed_user_id: int
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.allowed_user_id:
+            await interaction.response.send_message(
+                "Das ist nicht deine Auswahl.", ephemeral=True
+            )
+            return False
+        return True
+
+
+class DuoSearchComposeView(_OwnerCheckMixin):
+    """Ephemeral compose flow: pick a char + time windows, then publish."""
+
+    def __init__(
+        self,
+        cog: DuoCog,
+        user_id: int,
+        chars: list[tuple[str, str, int, int | None]],
+    ) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+        self.allowed_user_id = user_id
+        self.char_key: str | None = None
+        self.windows: list[str] = []
+
+        self.char_select = discord.ui.Select(
+            placeholder="Welchen Char dedizierst du?",
+            min_values=1,
+            max_values=1,
+            options=[
+                discord.SelectOption(
+                    label=name[:100],
+                    value=key,
+                    description=f"Level {level} · {_class_name(class_id)}"[:100],
+                )
+                for key, name, level, class_id in chars[:25]
+            ],
+        )
+        self.char_select.callback = self._on_char
+        self.add_item(self.char_select)
+
+        self.win_select = discord.ui.Select(
+            placeholder="Wann spielst du meist? (mehrere möglich)",
+            min_values=1,
+            max_values=len(TIME_WINDOWS),
+            options=[
+                discord.SelectOption(label=label, value=key)
+                for key, label in TIME_WINDOWS.items()
+            ],
+        )
+        self.win_select.callback = self._on_win
+        self.add_item(self.win_select)
+
+    async def _on_char(self, interaction: discord.Interaction) -> None:
+        self.char_key = self.char_select.values[0]
+        await interaction.response.defer()
+
+    async def _on_win(self, interaction: discord.Interaction) -> None:
+        self.windows = list(self.win_select.values)
+        await interaction.response.defer()
+
+    @discord.ui.button(label="Auf's Board", style=discord.ButtonStyle.success, row=2)
+    async def publish(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        if not self.char_key or not self.windows:
+            await interaction.response.send_message(
+                "Bitte erst Char **und** Zeiten wählen.", ephemeral=True
+            )
+            return
+        await self.cog.publish_search(interaction, self.char_key, self.windows)
+
+
+class DuoJoinCharSelectView(_OwnerCheckMixin):
+    """Requester without an own signup picks which char to bring."""
+
+    def __init__(
+        self,
+        cog: DuoCog,
+        owner_signup: DuoSignup,
+        chars: list[tuple[str, str, int, int | None]],
+    ) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+        self.owner_signup = owner_signup
+        self.allowed_user_id = 0  # set below to the requester
+        # The requester is whoever opened this; captured on first interaction.
+        self.select = discord.ui.Select(
+            placeholder="Dein Char",
+            min_values=1,
+            max_values=1,
+            options=[
+                discord.SelectOption(
+                    label=name[:100],
+                    value=f"{key}||{name}",
+                    description=f"Level {level} · {_class_name(class_id)}"[:100],
+                )
+                for key, name, level, class_id in chars[:25]
+            ],
+        )
+        self.select.callback = self._on_pick
+        self.add_item(self.select)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        # Bind to the first (and only intended) user.
+        if self.allowed_user_id == 0:
+            self.allowed_user_id = interaction.user.id
+        return await super().interaction_check(interaction)
+
+    async def _on_pick(self, interaction: discord.Interaction) -> None:
+        key, _, name = self.select.values[0].partition("||")
+        await self.cog._send_request(interaction, self.owner_signup, key, name)
+
+
+class DuoSwapCharSelectView(_OwnerCheckMixin):
+    """Team member picks a new dedicated character."""
+
+    def __init__(
+        self,
+        cog: DuoCog,
+        team: DuoTeam,
+        chars: list[tuple[str, str, int, int | None]],
+    ) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+        self.team = team
+        self.allowed_user_id = 0
+        self.select = discord.ui.Select(
+            placeholder="Neuer Char",
+            min_values=1,
+            max_values=1,
+            options=[
+                discord.SelectOption(
+                    label=name[:100],
+                    value=key,
+                    description=f"Level {level} · {_class_name(class_id)}"[:100],
+                )
+                for key, name, level, class_id in chars[:25]
+            ],
+        )
+        self.select.callback = self._on_pick
+        self.add_item(self.select)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if self.allowed_user_id == 0:
+            self.allowed_user_id = interaction.user.id
+        return await super().interaction_check(interaction)
+
+    async def _on_pick(self, interaction: discord.Interaction) -> None:
+        await self.cog.apply_char_swap(interaction, self.team, self.select.values[0])
+
+
+class DuoJoinRequestView(discord.ui.View):
+    """Transient accept/decline shown to a search-post owner."""
+
+    def __init__(
+        self,
+        cog: DuoCog,
+        owner_id: int,
+        requester_id: int,
+        requester_char_key: str,
+        requester_char_name: str,
+    ) -> None:
+        super().__init__(timeout=86400)
+        self.cog = cog
+        self.owner_id = owner_id
+        self.requester_id = requester_id
+        self.requester_char_key = requester_char_key
+        self.requester_char_name = requester_char_name
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.owner_id:
+            await interaction.response.send_message(
+                "Nur die gesuchte Person kann hier entscheiden.", ephemeral=True
+            )
+            return False
+        return True
+
+    @discord.ui.button(label="Annehmen", style=discord.ButtonStyle.success, emoji="✅")
+    async def accept(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.accept_request(
+            interaction,
+            self.owner_id,
+            self.requester_id,
+            self.requester_char_key,
+            self.requester_char_name,
+        )
+
+    @discord.ui.button(
+        label="Ablehnen", style=discord.ButtonStyle.secondary, emoji="✖️"
+    )
+    async def decline(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await interaction.response.edit_message(
+            content=f"<@{self.requester_id}> — Anfrage abgelehnt.", view=None
+        )
+
+
+class DuoStatusIdleView(discord.ui.View):
+    def __init__(self, cog: DuoCog) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Partner suchen", style=discord.ButtonStyle.success, emoji="🤝"
+    )
+    async def search(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.open_search(interaction)
+
+
+class DuoStatusSearchView(discord.ui.View):
+    def __init__(self, cog: DuoCog) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Suche bearbeiten", style=discord.ButtonStyle.primary, emoji="✏️"
+    )
+    async def edit(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.open_search(interaction)
+
+    @discord.ui.button(
+        label="Suche zurückziehen", style=discord.ButtonStyle.danger, emoji="🗑️"
+    )
+    async def withdraw(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.withdraw_search(interaction)
+
+
+class DuoStatusTeamView(discord.ui.View):
+    def __init__(self, cog: DuoCog, team: DuoTeam) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Team auflösen", style=discord.ButtonStyle.danger, emoji="🕯️"
+    )
+    async def disband(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await self.cog.disband_team_for(interaction)

--- a/src/lotus_bot/cogs/wow/duo_data.py
+++ b/src/lotus_bot/cogs/wow/duo_data.py
@@ -1,0 +1,506 @@
+"""SQLite storage for the WoW-Duo (level-partner) feature.
+
+Separate database file from :class:`WoWData` so the duo feature owns its own
+schema and migrations, but same on-disk directory. Structure and idioms mirror
+``WoWData``: lazy connection, WAL journal, idempotent :meth:`init_db`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import aiosqlite
+
+from lotus_bot.log_setup import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class DuoSignup:
+    discord_user_id: int
+    character_key: str
+    character_name: str
+    realm_slug: str
+    time_windows: str
+    note: str | None
+    post_id: int | None
+    created_at: str
+
+
+@dataclass
+class DuoTeam:
+    team_id: int
+    name: str
+    thread_id: int | None
+    status: str
+    created_at: str
+
+
+@dataclass
+class DuoTeamMember:
+    team_id: int
+    discord_user_id: int
+    character_key: str
+    character_name: str
+
+
+class DuoData:
+    """SQLite storage for duo signups and teams."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self.db: aiosqlite.Connection | None = None
+        self._init_done = False
+
+    async def _get_db(self) -> aiosqlite.Connection:
+        if self.db is None:
+            os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+            self.db = await aiosqlite.connect(self.db_path)
+            await self.db.execute("PRAGMA journal_mode=WAL")
+        return self.db
+
+    async def init_db(self) -> None:
+        if self._init_done:
+            return
+        db = await self._get_db()
+        # One active signup per Discord user (PK on discord_user_id). ``post_id``
+        # is the id of the public forum "Sucht Partner" post so we can find the
+        # signup back from a button click and delete the post on match.
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS duo_signups (
+                discord_user_id INTEGER PRIMARY KEY,
+                character_key TEXT NOT NULL,
+                character_name TEXT NOT NULL,
+                realm_slug TEXT NOT NULL,
+                time_windows TEXT NOT NULL,
+                note TEXT,
+                post_id INTEGER,
+                created_at TEXT NOT NULL
+            )
+            """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS duo_teams (
+                team_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                thread_id INTEGER,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS duo_team_members (
+                team_id INTEGER NOT NULL,
+                discord_user_id INTEGER NOT NULL,
+                character_key TEXT NOT NULL,
+                character_name TEXT NOT NULL,
+                PRIMARY KEY(team_id, discord_user_id)
+            )
+            """)
+        # Dedup guard so a duo level-milestone bonus is awarded exactly once
+        # per (team, level), even if a scan re-runs.
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS duo_milestone_events (
+                team_id INTEGER NOT NULL,
+                level INTEGER NOT NULL,
+                awarded_at TEXT NOT NULL,
+                PRIMARY KEY(team_id, level)
+            )
+            """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS duo_settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """)
+        await db.commit()
+        self._init_done = True
+        logger.info("[DuoData] SQLite database initialized.")
+
+    async def get_setting(self, key: str) -> str | None:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute("SELECT value FROM duo_settings WHERE key = ?", (key,))
+        row = await cur.fetchone()
+        return row[0] if row else None
+
+    async def set_setting(self, key: str, value: str) -> None:
+        await self.init_db()
+        db = await self._get_db()
+        await db.execute(
+            """
+            INSERT INTO duo_settings(key, value) VALUES(?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            (key, value),
+        )
+        await db.commit()
+
+    async def close(self) -> None:
+        if self.db is not None:
+            await self.db.close()
+            self.db = None
+            self._init_done = False
+
+    # ---- signups ----
+
+    async def upsert_signup(
+        self,
+        discord_user_id: int,
+        character_key: str,
+        character_name: str,
+        realm_slug: str,
+        time_windows: str,
+        note: str | None,
+    ) -> DuoSignup:
+        """Create or replace the caller's single open signup.
+
+        ``post_id`` is reset to NULL — the caller creates the forum post
+        afterwards and records its id via :meth:`set_signup_post`.
+        """
+        await self.init_db()
+        db = await self._get_db()
+        now = datetime.utcnow().isoformat()
+        await db.execute(
+            """
+            INSERT INTO duo_signups(
+                discord_user_id, character_key, character_name, realm_slug,
+                time_windows, note, post_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+            ON CONFLICT(discord_user_id) DO UPDATE SET
+                character_key = excluded.character_key,
+                character_name = excluded.character_name,
+                realm_slug = excluded.realm_slug,
+                time_windows = excluded.time_windows,
+                note = excluded.note,
+                post_id = NULL,
+                created_at = excluded.created_at
+            """,
+            (
+                discord_user_id,
+                character_key,
+                character_name,
+                realm_slug,
+                time_windows,
+                (note or None),
+                now,
+            ),
+        )
+        await db.commit()
+        signup = await self.get_signup(discord_user_id)
+        if signup is None:  # pragma: no cover - defensive
+            raise RuntimeError("Signup creation failed")
+        return signup
+
+    async def set_signup_post(self, discord_user_id: int, post_id: int) -> None:
+        await self.init_db()
+        db = await self._get_db()
+        await db.execute(
+            "UPDATE duo_signups SET post_id = ? WHERE discord_user_id = ?",
+            (post_id, discord_user_id),
+        )
+        await db.commit()
+
+    async def get_signup(self, discord_user_id: int) -> DuoSignup | None:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT discord_user_id, character_key, character_name, realm_slug,
+                   time_windows, note, post_id, created_at
+              FROM duo_signups WHERE discord_user_id = ?
+            """,
+            (discord_user_id,),
+        )
+        row = await cur.fetchone()
+        return _signup_from_row(row) if row else None
+
+    async def get_signup_by_post(self, post_id: int) -> DuoSignup | None:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT discord_user_id, character_key, character_name, realm_slug,
+                   time_windows, note, post_id, created_at
+              FROM duo_signups WHERE post_id = ?
+            """,
+            (post_id,),
+        )
+        row = await cur.fetchone()
+        return _signup_from_row(row) if row else None
+
+    async def remove_signup(self, discord_user_id: int) -> bool:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            "DELETE FROM duo_signups WHERE discord_user_id = ?",
+            (discord_user_id,),
+        )
+        await db.commit()
+        return cur.rowcount > 0
+
+    async def list_signups(self, exclude_user_id: int | None = None) -> list[DuoSignup]:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute("""
+            SELECT discord_user_id, character_key, character_name, realm_slug,
+                   time_windows, note, post_id, created_at
+              FROM duo_signups
+             ORDER BY created_at
+            """)
+        rows = await cur.fetchall()
+        signups = [_signup_from_row(row) for row in rows]
+        if exclude_user_id is not None:
+            signups = [s for s in signups if s.discord_user_id != exclude_user_id]
+        return signups
+
+    async def signup_count(self) -> int:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute("SELECT COUNT(*) FROM duo_signups")
+        row = await cur.fetchone()
+        return int(row[0]) if row else 0
+
+    # ---- teams ----
+
+    async def create_team(
+        self,
+        name: str,
+        thread_id: int | None,
+        members: list[tuple[int, str, str]],
+    ) -> DuoTeam:
+        """Create an active team with its members.
+
+        ``members`` items are ``(discord_user_id, character_key, character_name)``.
+        """
+        await self.init_db()
+        db = await self._get_db()
+        now = datetime.utcnow().isoformat()
+        cur = await db.execute(
+            """
+            INSERT INTO duo_teams(name, thread_id, status, created_at)
+            VALUES (?, ?, 'active', ?)
+            """,
+            (name, thread_id, now),
+        )
+        team_id = cur.lastrowid
+        for user_id, character_key, character_name in members:
+            await db.execute(
+                """
+                INSERT INTO duo_team_members(
+                    team_id, discord_user_id, character_key, character_name
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (team_id, user_id, character_key, character_name),
+            )
+        await db.commit()
+        team = await self.get_team(int(team_id))
+        if team is None:  # pragma: no cover - defensive
+            raise RuntimeError("Team creation failed")
+        return team
+
+    async def set_team_thread(self, team_id: int, thread_id: int) -> None:
+        await self.init_db()
+        db = await self._get_db()
+        await db.execute(
+            "UPDATE duo_teams SET thread_id = ? WHERE team_id = ?",
+            (thread_id, team_id),
+        )
+        await db.commit()
+
+    async def get_team(self, team_id: int) -> DuoTeam | None:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT team_id, name, thread_id, status, created_at
+              FROM duo_teams WHERE team_id = ?
+            """,
+            (team_id,),
+        )
+        row = await cur.fetchone()
+        return _team_from_row(row) if row else None
+
+    async def get_team_by_thread(self, thread_id: int) -> DuoTeam | None:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT team_id, name, thread_id, status, created_at
+              FROM duo_teams WHERE thread_id = ?
+            """,
+            (thread_id,),
+        )
+        row = await cur.fetchone()
+        return _team_from_row(row) if row else None
+
+    async def active_team_for_user(self, discord_user_id: int) -> DuoTeam | None:
+        """The active (or mourning) team the user currently belongs to."""
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT t.team_id, t.name, t.thread_id, t.status, t.created_at
+              FROM duo_teams t
+              JOIN duo_team_members m ON m.team_id = t.team_id
+             WHERE m.discord_user_id = ? AND t.status != 'disbanded'
+             ORDER BY t.created_at DESC
+             LIMIT 1
+            """,
+            (discord_user_id,),
+        )
+        row = await cur.fetchone()
+        return _team_from_row(row) if row else None
+
+    async def active_team_by_character(self, character_key: str) -> DuoTeam | None:
+        """The active/mourning team a given character currently plays in."""
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT t.team_id, t.name, t.thread_id, t.status, t.created_at
+              FROM duo_teams t
+              JOIN duo_team_members m ON m.team_id = t.team_id
+             WHERE m.character_key = ? AND t.status != 'disbanded'
+             ORDER BY t.created_at DESC
+             LIMIT 1
+            """,
+            (character_key,),
+        )
+        row = await cur.fetchone()
+        return _team_from_row(row) if row else None
+
+    async def team_members(self, team_id: int) -> list[DuoTeamMember]:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            SELECT team_id, discord_user_id, character_key, character_name
+              FROM duo_team_members WHERE team_id = ?
+             ORDER BY discord_user_id
+            """,
+            (team_id,),
+        )
+        rows = await cur.fetchall()
+        return [_member_from_row(row) for row in rows]
+
+    async def set_team_status(self, team_id: int, status: str) -> None:
+        await self.init_db()
+        db = await self._get_db()
+        await db.execute(
+            "UPDATE duo_teams SET status = ? WHERE team_id = ?",
+            (status, team_id),
+        )
+        await db.commit()
+
+    async def set_team_name(self, team_id: int, name: str) -> None:
+        await self.init_db()
+        db = await self._get_db()
+        await db.execute(
+            "UPDATE duo_teams SET name = ? WHERE team_id = ?",
+            (name, team_id),
+        )
+        await db.commit()
+
+    async def swap_member_character(
+        self,
+        team_id: int,
+        discord_user_id: int,
+        character_key: str,
+        character_name: str,
+    ) -> None:
+        """Point a team member at a freshly-dedicated character (HC revive)."""
+        await self.init_db()
+        db = await self._get_db()
+        await db.execute(
+            """
+            UPDATE duo_team_members
+               SET character_key = ?, character_name = ?
+             WHERE team_id = ? AND discord_user_id = ?
+            """,
+            (character_key, character_name, team_id, discord_user_id),
+        )
+        await db.commit()
+
+    async def disband_team(self, team_id: int) -> None:
+        """Mark a team disbanded (rows kept for history)."""
+        await self.set_team_status(team_id, "disbanded")
+
+    async def used_team_names(self) -> set[str]:
+        """All non-disbanded team names, to avoid handing out a duplicate."""
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute("SELECT name FROM duo_teams WHERE status != 'disbanded'")
+        rows = await cur.fetchall()
+        return {str(row[0]) for row in rows}
+
+    async def active_teams(self) -> list[DuoTeam]:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute("""
+            SELECT team_id, name, thread_id, status, created_at
+              FROM duo_teams WHERE status != 'disbanded'
+             ORDER BY created_at
+            """)
+        rows = await cur.fetchall()
+        return [_team_from_row(row) for row in rows]
+
+    # ---- duo milestone dedup ----
+
+    async def duo_milestone_exists(self, team_id: int, level: int) -> bool:
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            "SELECT 1 FROM duo_milestone_events WHERE team_id = ? AND level = ?",
+            (team_id, int(level)),
+        )
+        return await cur.fetchone() is not None
+
+    async def record_duo_milestone(self, team_id: int, level: int) -> bool:
+        """Reserve the duo-milestone slot; ``True`` only on the first call."""
+        await self.init_db()
+        db = await self._get_db()
+        cur = await db.execute(
+            """
+            INSERT OR IGNORE INTO duo_milestone_events(team_id, level, awarded_at)
+            VALUES (?, ?, ?)
+            """,
+            (team_id, int(level), datetime.utcnow().isoformat()),
+        )
+        await db.commit()
+        return cur.rowcount > 0
+
+
+def _signup_from_row(row: tuple[Any, ...]) -> DuoSignup:
+    return DuoSignup(
+        discord_user_id=row[0],
+        character_key=row[1],
+        character_name=row[2],
+        realm_slug=row[3],
+        time_windows=row[4],
+        note=row[5],
+        post_id=row[6],
+        created_at=row[7],
+    )
+
+
+def _team_from_row(row: tuple[Any, ...]) -> DuoTeam:
+    return DuoTeam(
+        team_id=row[0],
+        name=row[1],
+        thread_id=row[2],
+        status=row[3],
+        created_at=row[4],
+    )
+
+
+def _member_from_row(row: tuple[Any, ...]) -> DuoTeamMember:
+    return DuoTeamMember(
+        team_id=row[0],
+        discord_user_id=row[1],
+        character_key=row[2],
+        character_name=row[3],
+    )

--- a/src/lotus_bot/cogs/wow/duo_logic.py
+++ b/src/lotus_bot/cogs/wow/duo_logic.py
@@ -1,0 +1,165 @@
+"""Pure, Discord-free helpers for the WoW-Duo (level-partner) feature.
+
+Kept separate from :mod:`duo_cog` so the matching maths, time-window encoding
+and team-name pool can be unit-tested without a running bot. Nothing in here
+touches SQLite or discord.py.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable
+
+# Coarse play-time windows. Deliberately few and fuzzy so casual players can
+# pick "when do I usually play" in a single multi-select instead of fiddling
+# with clock times. Order here is the canonical display/storage order.
+TIME_WINDOWS: dict[str, str] = {
+    "wd_vormittag": "Werktags vormittags",
+    "wd_nachmittag": "Werktags nachmittags",
+    "wd_abend": "Werktags abends",
+    "we_tag": "Wochenende tagsüber",
+    "we_abend": "Wochenende abends",
+    "spaet": "Spätabends & Nachts",
+}
+
+# Curated pool of duo team names. On match the bot proposes a random unused
+# one; members can rename. Kept WoW/Horde-flavoured and short so they read
+# well as a forum-post title ("🤝 Team Aschefaust").
+TEAM_NAME_POOL: list[str] = [
+    "Team Phoenix",
+    "Team Aschefaust",
+    "Team Nachtklinge",
+    "Team Blutmond",
+    "Team Wolfsrudel",
+    "Team Donnerhuf",
+    "Team Schattenpfad",
+    "Team Eisenwolf",
+    "Team Grimmzahn",
+    "Team Sturmwind",
+    "Team Kriegsherz",
+    "Team Rabenschwinge",
+    "Team Glutkern",
+    "Team Frostbiss",
+    "Team Wildherz",
+    "Team Silberklaue",
+    "Team Drachenblut",
+    "Team Dornenritter",
+    "Team Mondschatten",
+    "Team Feuersturm",
+    "Team Steinfaust",
+    "Team Geisterwolf",
+    "Team Schwarzdorn",
+    "Team Bluteiche",
+    "Team Wüstenwind",
+    "Team Nebelgänger",
+    "Team Flammenzunge",
+    "Team Eisenherz",
+    "Team Schädelbrecher",
+    "Team Klingenwirbel",
+]
+
+
+def encode_windows(keys: Iterable[str]) -> str:
+    """Serialise selected window keys to a canonical, comma-separated string.
+
+    Invalid keys are dropped, duplicates collapsed, and the result is ordered
+    to match :data:`TIME_WINDOWS` so equality/round-trips are stable.
+    """
+    selected = {k for k in keys if k in TIME_WINDOWS}
+    return ",".join(key for key in TIME_WINDOWS if key in selected)
+
+
+def decode_windows(raw: str | None) -> list[str]:
+    """Parse a stored window string back into canonical-ordered valid keys."""
+    if not raw:
+        return []
+    parts = {part.strip() for part in raw.split(",") if part.strip()}
+    return [key for key in TIME_WINDOWS if key in parts]
+
+
+def window_labels(keys: Iterable[str]) -> list[str]:
+    """Human-readable labels for the given window keys, canonical order."""
+    key_set = {k for k in keys if k in TIME_WINDOWS}
+    return [label for key, label in TIME_WINDOWS.items() if key in key_set]
+
+
+def format_windows(keys: Iterable[str]) -> str:
+    """Comma-joined labels, or a dash when nothing is set."""
+    labels = window_labels(keys)
+    return ", ".join(labels) if labels else "—"
+
+
+def overlap_keys(a: Iterable[str], b: Iterable[str]) -> list[str]:
+    """Shared window keys between two selections, canonical order."""
+    set_a = {k for k in a if k in TIME_WINDOWS}
+    set_b = {k for k in b if k in TIME_WINDOWS}
+    shared = set_a & set_b
+    return [key for key in TIME_WINDOWS if key in shared]
+
+
+@dataclass
+class Candidate:
+    """A potential partner ranked against the searching user."""
+
+    discord_user_id: int
+    character_name: str
+    level: int
+    windows: list[str]
+    overlap: list[str]
+    level_distance: int
+
+    @property
+    def overlap_count(self) -> int:
+        return len(self.overlap)
+
+
+def rank_candidates(
+    my_windows: Iterable[str],
+    my_level: int,
+    others: Iterable[tuple[int, str, int, list[str]]],
+) -> list[Candidate]:
+    """Rank open signups against the searcher.
+
+    ``others`` items are ``(discord_user_id, character_name, level, windows)``.
+    Best first: most time-window overlap, then smallest level distance, then
+    name for a stable tie-break. Candidates with zero overlap are still
+    returned (so a lonely searcher always sees *someone*) but sort last.
+    """
+    my_window_list = [k for k in my_windows if k in TIME_WINDOWS]
+    ranked: list[Candidate] = []
+    for user_id, name, level, windows in others:
+        shared = overlap_keys(my_window_list, windows)
+        ranked.append(
+            Candidate(
+                discord_user_id=user_id,
+                character_name=name,
+                level=level,
+                windows=[k for k in windows if k in TIME_WINDOWS],
+                overlap=shared,
+                level_distance=abs(int(level) - int(my_level)),
+            )
+        )
+    ranked.sort(
+        key=lambda c: (-c.overlap_count, c.level_distance, c.character_name.casefold())
+    )
+    return ranked
+
+
+def pick_team_name(used: Iterable[str], rng: random.Random | None = None) -> str:
+    """Return a team name not already in ``used``.
+
+    Picks randomly from the free names in the pool. If every pooled name is
+    taken, falls back to numbered variants ("Team Phoenix 2", …) so team
+    creation can never fail for lack of a name.
+    """
+    rng = rng or random
+    used_set = {name.casefold() for name in used}
+    free = [name for name in TEAM_NAME_POOL if name.casefold() not in used_set]
+    if free:
+        return rng.choice(free)
+    base = rng.choice(TEAM_NAME_POOL)
+    suffix = 2
+    while f"{base} {suffix}".casefold() in used_set:
+        suffix += 1
+    return f"{base} {suffix}"

--- a/src/lotus_bot/cogs/wow/duo_slash.py
+++ b/src/lotus_bot/cogs/wow/duo_slash.py
@@ -1,0 +1,49 @@
+import discord
+from discord import app_commands
+
+from lotus_bot.log_setup import get_logger
+from lotus_bot.permissions import moderator_only
+
+logger = get_logger(__name__)
+
+duo_group = app_commands.Group(
+    name="duo",
+    description="Zusammen leveln – finde einen Level-Partner",
+)
+
+
+@duo_group.command(
+    name="status", description="Zeigt deinen Duo-Status (suchst du / im Team)"
+)
+async def duo_status(interaction: discord.Interaction):
+    cog = interaction.client.get_cog("DuoCog")
+    if cog is None:
+        await interaction.response.send_message(
+            "❌ Duo-System nicht verfügbar.", ephemeral=True
+        )
+        return
+    payload = await cog._status_payload(interaction.user.id)
+    await interaction.response.send_message(**payload, ephemeral=True)
+
+
+@duo_group.command(
+    name="publish", description="Veröffentlicht/aktualisiert den Duo-Hub (nur Mods)"
+)
+@moderator_only()
+@app_commands.default_permissions(manage_guild=True)
+async def duo_publish(interaction: discord.Interaction):
+    logger.info(f"/duo publish by {interaction.user}")
+    cog = interaction.client.get_cog("DuoCog")
+    if cog is None:
+        await interaction.response.send_message(
+            "❌ Duo-System nicht verfügbar.", ephemeral=True
+        )
+        return
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        await cog.publish_hub()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("[DuoCommands] Hub-Publish fehlgeschlagen: %s", exc, exc_info=True)
+        await interaction.followup.send("❌ Hub-Publish fehlgeschlagen.")
+        return
+    await interaction.followup.send("✅ Duo-Hub veröffentlicht/aktualisiert.")

--- a/tests/wow/test_duo_cog.py
+++ b/tests/wow/test_duo_cog.py
@@ -1,0 +1,168 @@
+"""Focused tests for the DuoCog hook logic (milestone/death).
+
+The forum/thread wiring is faked; the point is to lock down the decision
+logic: duo bonus only when BOTH partners reached a milestone, exactly once,
+and a memorial that flips the team into mourning on a partner's death.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from lotus_bot.cogs.wow.duo_cog import DUO_MILESTONE_BONUS, DuoCog
+from lotus_bot.cogs.wow.duo_data import DuoData
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeWowData:
+    def __init__(self, levels, milestones):
+        self._levels = levels
+        self._milestones = milestones
+
+    async def milestone_exists(self, character_key, level):
+        return (character_key, level) in self._milestones
+
+    async def get_snapshot(self):
+        return {
+            key: SimpleNamespace(
+                character_key=key,
+                name=key,
+                level=level,
+                class_id=1,
+                race_id=2,
+                is_ghost=False,
+            )
+            for key, level in self._levels.items()
+        }
+
+
+class FakeChampion:
+    def __init__(self):
+        self.updates = []
+
+    async def update_user_score(self, user_id, delta, reason):
+        self.updates.append((user_id, delta, reason))
+        return delta
+
+
+class FakeBot:
+    def __init__(self, wow, champion):
+        self._wow = wow
+        self._champion = champion
+        self.views = []
+
+    def add_view(self, view):
+        self.views.append(view)
+
+    def get_cog(self, name):
+        return {"WoWCog": self._wow, "ChampionCog": self._champion}.get(name)
+
+    def get_channel(self, channel_id):
+        return None
+
+    async def wait_until_ready(self):
+        return
+
+
+class FakeThread:
+    def __init__(self):
+        self.sends = []
+        self.edits = []
+
+    async def send(self, content=None, embed=None, **kwargs):
+        self.sends.append((content, embed))
+        return SimpleNamespace(pin=self._noop)
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+    async def _noop(self):
+        return
+
+
+async def _make_cog(tmp_path, levels, milestones):
+    champion = FakeChampion()
+    wow = SimpleNamespace(data=FakeWowData(levels, milestones))
+    cog = DuoCog(FakeBot(wow, champion))
+    # Kill the background startup task and repoint at a throwaway DB before any
+    # await touches the default on-disk path.
+    for task in list(cog.tasks):
+        task.cancel()
+    cog.data = DuoData(str(tmp_path / "duo.db"))
+    thread = FakeThread()
+
+    async def _fetch(_thread_id):
+        return thread
+
+    cog._fetch_thread = _fetch
+    return cog, champion, thread
+
+
+async def test_milestone_bonus_only_when_both_reached_and_once(tmp_path):
+    cog, champion, thread = await _make_cog(
+        tmp_path,
+        levels={"c1": 40, "c2": 40},
+        milestones={("c1", 40), ("c2", 40)},
+    )
+    team = await cog.data.create_team(
+        "Team X", 100, [(1, "c1", "Ash"), (2, "c2", "Nyx")]
+    )
+
+    await cog.on_character_milestone("c2", 40)
+
+    bonus = DUO_MILESTONE_BONUS[40]
+    assert sorted(u[0] for u in champion.updates) == [1, 2]
+    assert all(u[1] == bonus for u in champion.updates)
+    assert await cog.data.duo_milestone_exists(team.team_id, 40) is True
+    assert any("gemeinsam" in (c or "").lower() for c, _ in thread.sends)
+
+    # Re-firing the same milestone must not double-award.
+    champion.updates.clear()
+    await cog.on_character_milestone("c2", 40)
+    assert champion.updates == []
+
+
+async def test_milestone_nudge_when_only_one_reached(tmp_path):
+    cog, champion, thread = await _make_cog(
+        tmp_path,
+        levels={"c1": 35, "c2": 40},
+        milestones={("c2", 40)},
+    )
+    team = await cog.data.create_team(
+        "Team Y", 101, [(1, "c1", "Ash"), (2, "c2", "Nyx")]
+    )
+
+    await cog.on_character_milestone("c2", 40)
+
+    assert champion.updates == []
+    assert await cog.data.duo_milestone_exists(team.team_id, 40) is False
+    assert len(thread.sends) == 1  # a nudge, not a celebration
+
+
+async def test_death_posts_memorial_and_sets_mourning(tmp_path):
+    cog, champion, thread = await _make_cog(
+        tmp_path, levels={"c1": 42, "c2": 42}, milestones=set()
+    )
+    team = await cog.data.create_team(
+        "Team Z", 102, [(1, "c1", "Ash"), (2, "c2", "Nyx")]
+    )
+
+    await cog.on_character_death("c1", 42)
+
+    assert thread.sends, "expected a memorial message"
+    _, embed = thread.sends[0]
+    assert embed is not None
+    assert (await cog.data.get_team(team.team_id)).status == "mourning"
+
+
+async def test_milestone_ignores_untracked_level(tmp_path):
+    cog, champion, thread = await _make_cog(
+        tmp_path, levels={"c1": 42, "c2": 42}, milestones=set()
+    )
+    await cog.data.create_team("Team Q", 103, [(1, "c1", "A"), (2, "c2", "B")])
+
+    await cog.on_character_milestone("c1", 42)  # 42 is not a milestone level
+
+    assert champion.updates == []
+    assert thread.sends == []

--- a/tests/wow/test_duo_data.py
+++ b/tests/wow/test_duo_data.py
@@ -1,0 +1,117 @@
+import pytest
+
+from lotus_bot.cogs.wow.duo_data import DuoData
+
+pytestmark = pytest.mark.asyncio
+
+
+def _data(tmp_path):
+    return DuoData(str(tmp_path / "duo.db"))
+
+
+async def test_signup_upsert_get_and_by_post(tmp_path):
+    data = _data(tmp_path)
+    await data.upsert_signup(
+        1, "id:10", "Grimjaw", "soulseeker", "wd_abend,spaet", None
+    )
+    signup = await data.get_signup(1)
+    assert signup is not None
+    assert signup.character_name == "Grimjaw"
+    assert signup.post_id is None
+
+    await data.set_signup_post(1, 999)
+    assert (await data.get_signup(1)).post_id == 999
+    by_post = await data.get_signup_by_post(999)
+    assert by_post is not None and by_post.discord_user_id == 1
+
+    # Upsert replaces and resets the post id.
+    await data.upsert_signup(1, "id:11", "Nightblade", "soulseeker", "we_abend", "hi")
+    refreshed = await data.get_signup(1)
+    assert refreshed.character_key == "id:11"
+    assert refreshed.note == "hi"
+    assert refreshed.post_id is None
+
+
+async def test_list_signups_excludes_user(tmp_path):
+    data = _data(tmp_path)
+    await data.upsert_signup(1, "id:1", "A", "r", "wd_abend", None)
+    await data.upsert_signup(2, "id:2", "B", "r", "wd_abend", None)
+    all_signups = await data.list_signups()
+    assert {s.discord_user_id for s in all_signups} == {1, 2}
+    without_1 = await data.list_signups(exclude_user_id=1)
+    assert {s.discord_user_id for s in without_1} == {2}
+    assert await data.signup_count() == 2
+
+
+async def test_remove_signup(tmp_path):
+    data = _data(tmp_path)
+    await data.upsert_signup(1, "id:1", "A", "r", "wd_abend", None)
+    assert await data.remove_signup(1) is True
+    assert await data.remove_signup(1) is False
+    assert await data.get_signup(1) is None
+
+
+async def test_team_lifecycle_and_lookups(tmp_path):
+    data = _data(tmp_path)
+    team = await data.create_team(
+        "Team Phoenix",
+        555,
+        [(1, "id:1", "Ashfist"), (2, "id:2", "Nightblade")],
+    )
+    assert team.status == "active"
+    assert team.name == "Team Phoenix"
+
+    assert (await data.get_team_by_thread(555)).team_id == team.team_id
+    assert (await data.active_team_for_user(1)).team_id == team.team_id
+    assert (await data.active_team_for_user(2)).team_id == team.team_id
+    assert (await data.active_team_by_character("id:2")).team_id == team.team_id
+
+    members = await data.team_members(team.team_id)
+    assert {m.discord_user_id for m in members} == {1, 2}
+
+    assert await data.used_team_names() == {"Team Phoenix"}
+    assert len(await data.active_teams()) == 1
+
+
+async def test_swap_member_character(tmp_path):
+    data = _data(tmp_path)
+    team = await data.create_team("T", 1, [(1, "id:1", "Old"), (2, "id:2", "Keep")])
+    await data.swap_member_character(team.team_id, 1, "id:99", "Fresh")
+    members = {m.discord_user_id: m for m in await data.team_members(team.team_id)}
+    assert members[1].character_key == "id:99"
+    assert members[1].character_name == "Fresh"
+    assert members[2].character_key == "id:2"
+    # The new character is now discoverable, the old one is not.
+    assert (await data.active_team_by_character("id:99")).team_id == team.team_id
+    assert await data.active_team_by_character("id:1") is None
+
+
+async def test_disband_hides_team_from_active_lookups(tmp_path):
+    data = _data(tmp_path)
+    team = await data.create_team("T", 1, [(1, "id:1", "A"), (2, "id:2", "B")])
+    await data.disband_team(team.team_id)
+    assert await data.active_team_for_user(1) is None
+    assert await data.active_team_by_character("id:1") is None
+    assert await data.used_team_names() == set()
+    assert await data.active_teams() == []
+    # Row still exists for history.
+    assert (await data.get_team(team.team_id)).status == "disbanded"
+
+
+async def test_duo_milestone_dedup(tmp_path):
+    data = _data(tmp_path)
+    team = await data.create_team("T", 1, [(1, "id:1", "A"), (2, "id:2", "B")])
+    assert await data.duo_milestone_exists(team.team_id, 40) is False
+    assert await data.record_duo_milestone(team.team_id, 40) is True
+    assert await data.duo_milestone_exists(team.team_id, 40) is True
+    # Second call is a no-op (already recorded).
+    assert await data.record_duo_milestone(team.team_id, 40) is False
+
+
+async def test_settings_round_trip(tmp_path):
+    data = _data(tmp_path)
+    assert await data.get_setting("hub_thread_id") is None
+    await data.set_setting("hub_thread_id", "123")
+    assert await data.get_setting("hub_thread_id") == "123"
+    await data.set_setting("hub_thread_id", "456")
+    assert await data.get_setting("hub_thread_id") == "456"

--- a/tests/wow/test_duo_logic.py
+++ b/tests/wow/test_duo_logic.py
@@ -1,0 +1,67 @@
+import random
+
+from lotus_bot.cogs.wow.duo_logic import (
+    TEAM_NAME_POOL,
+    TIME_WINDOWS,
+    decode_windows,
+    encode_windows,
+    format_windows,
+    overlap_keys,
+    pick_team_name,
+    rank_candidates,
+)
+
+
+def test_encode_windows_is_canonical_and_filters_invalid():
+    # Unknown keys dropped, duplicates collapsed, order follows TIME_WINDOWS.
+    encoded = encode_windows(["spaet", "wd_abend", "bogus", "wd_abend"])
+    assert encoded == "wd_abend,spaet"
+
+
+def test_decode_round_trips_and_ignores_junk():
+    assert decode_windows("wd_abend,spaet") == ["wd_abend", "spaet"]
+    assert decode_windows("") == []
+    assert decode_windows(None) == []
+    assert decode_windows("bogus,wd_vormittag") == ["wd_vormittag"]
+
+
+def test_format_windows_labels_and_dash():
+    assert format_windows(["wd_abend"]) == TIME_WINDOWS["wd_abend"]
+    assert format_windows([]) == "—"
+
+
+def test_overlap_keys_intersection_in_canonical_order():
+    a = ["wd_abend", "we_abend", "spaet"]
+    b = ["spaet", "wd_abend", "we_tag"]
+    assert overlap_keys(a, b) == ["wd_abend", "spaet"]
+
+
+def test_rank_candidates_orders_by_overlap_then_level_then_name():
+    my_windows = ["wd_abend", "we_abend"]
+    my_level = 30
+    others = [
+        # (user_id, name, level, windows)
+        (1, "Zena", 31, ["wd_abend"]),  # overlap 1, dist 1
+        (2, "Arno", 60, ["wd_abend", "we_abend"]),  # overlap 2, dist 30
+        (3, "Bela", 33, ["wd_abend", "we_abend"]),  # overlap 2, dist 3
+        (4, "Cara", 30, ["wd_vormittag"]),  # overlap 0
+    ]
+    ranked = rank_candidates(my_windows, my_level, others)
+    # Best overlap first; within same overlap, closer level first.
+    assert [c.discord_user_id for c in ranked] == [3, 2, 1, 4]
+    assert ranked[0].overlap_count == 2
+    assert ranked[-1].overlap_count == 0
+
+
+def test_pick_team_name_avoids_used():
+    used = set(TEAM_NAME_POOL[:-1])  # only the last name is free
+    name = pick_team_name(used, rng=random.Random(0))
+    assert name == TEAM_NAME_POOL[-1]
+
+
+def test_pick_team_name_falls_back_to_numbered_when_pool_exhausted():
+    used = set(TEAM_NAME_POOL)
+    name = pick_team_name(used, rng=random.Random(1))
+    assert name.endswith(" 2")
+    base = name[: -len(" 2")]
+    assert base in TEAM_NAME_POOL


### PR DESCRIPTION
## Was & Warum

Neues Feature **WoW-Duo** (Level-Partner-Matchmaking) für den Forum-Channel `wow-duo`. Ziel: dem Wegsterben/Alleine-Leveln in Classic **Hardcore** entgegenwirken. Member dedizieren einen geclaimten Char, finden über ein öffentliches Board einen Partner und leveln als Team zusammen — mehr Spaß, sicherer, stärkere Gildenbindung.

## Ablauf

1. Angepinnter **Hub-Post** im Forum mit Buttons: *Partner suchen · Mein Status · Hilfe*.
2. **Partner suchen** → Char wählen + grobe Zeitfenster anklicken → öffentlicher Suchpost erscheint (Board).
3. Klick auf **🤝 Mit mir leveln** in einem Suchpost → Anfrage → Zustimmung → **Team-Post „🤝 Team Phoenix"** entsteht, beide werden hinzugefügt, Such-Posts verschwinden.
4. Im Team-Thread automatisch: **Level-Meilensteine**, **Champion-Bonus wenn beide ankommen**, **🕯️ Memorial wenn ein Partner fällt** mit *Weiterspielen* (neuen Char wählen) oder *auflösen*.

## Änderungen

- `duo_logic.py` — Zeitfenster, Matching-Scoring (Overlap → Level-Nähe), Team-Namen-Pool (reine Logik)
- `duo_data.py` — eigene DB `data/pers/wow/duo.db`: Signups, Teams, Members, Milestone-Dedup, Settings
- `duo_cog.py` — Forum-Hub, Such-/Match-/Team-Flows, persistente Views, Tod-/Meilenstein-Hooks
- `duo_slash.py` — `/duo status` (User), `/duo publish` (Mod)
- `cog.py` — Hooks in `_record_public_events` rufen den DuoCog bei Tod/Meilenstein (`get_cog`-Muster wie beim ChampionCog)
- `__init__.py` — DuoCog + `/duo`-Gruppe registriert

## Für Reviewer wichtig

- **Kopplung minimal-invasiv:** Kein Umbau am WoW-Scan; die zwei neuen Hook-Aufrufe sind fire-and-forget mit try/except. Der Meilenstein-Hook läuft **nach** `record_milestone`, damit der „beide erreicht"-Check timing-unabhängig ist (nutzt `milestone_exists`, nicht den erst nach dem Scan geschriebenen Snapshot).
- **discord.py 2.7:** `ForumChannel.create_thread` kennt kein `view=` — persistente Buttons werden per `message.edit(view=…)` auf die Startnachricht gesetzt.
- **Bot-Rechte im `wow-duo`-Forum nötig:** Kanal ansehen, Beiträge erstellen, Nachrichten senden in Threads, Threads verwalten (Pinnen/Tags/Archivieren/Löschen). Optional Kanäle verwalten (nur zum Anlegen der 4 Forum-Tags; degradiert sonst sauber ohne Tags).
- **Design-Entscheidung:** eine aktive Suche bzw. ein Team pro Person (Partner bewusst „monogam").

## Tests

392 Tests grün, Black sauber. Abgedeckt: Logik, Datenschicht, und die Hook-Entscheidungen (Bonus nur wenn beide + kein Doppel-Bonus, Nudge bei nur einem, Tod → Memorial/Mourning). Die Discord-/Forum-Verdrahtung braucht einen Live-Smoke-Test nach Deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
